### PR TITLE
Use AWS SDK to create log groups and subscription filters

### DIFF
--- a/serverless/README.md
+++ b/serverless/README.md
@@ -105,7 +105,7 @@ enableXrayTracing: false
 # Enable tracing on Lambda function using dd-trace, datadog's APM library. Requires datadog log forwarder to be set up. Defaults to true.
 enableDDTracing: true
 
-# When set, the plugin will try to subscribe the lambda's cloudwatch log groups to the forwarder with the given arn.
+# When set, the plugin will try to subscribe the lambda's cloudwatch log groups to the forwarder with the given arn. If you are deploying your Lambda functions for the first time and no log groups currently exist, you will need to provide the 'FunctionName' property for your Lambdas so the macro can automatically create the log groups and add the subscriptions.
 forwarderArn: arn:aws:lambda:us-east-1:000000000000:function:datadog-forwarder
 
 # The name of the CloudFormation stack being deployed. Only required when forwarderArn is provided and Lambda functions are dynamically named (when the `FunctionName` property isn't provided for a Lambda). For how to add this parameter for SAM and CDK, see examples below.
@@ -201,4 +201,32 @@ module.exports.myHandler = datadog(
 ```python
 @datadog_lambda_wrapper # This wrapper is NOT needed when using this plugin
 def lambda_handler(event, context):
+```
+
+## FAQ
+
+### I'm seeing this error message: 'FunctionName' property is undefined for...
+This error occurs when you provide a `forwarderArn` and are deploying your Lambda function for the first time, so no log group currently exists. In order for the macro to create this log group and the correct subscriptions for you, you will need to provide the `FunctionName` property on your Lambda. For examples, see below:
+
+**AWS SAM**
+```yml
+Resources:
+  MyLambda:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: index.handler
+      Runtime: nodejs12.x
+      FunctionName: MyFunctionName # Add this property to your Lambdas
+```
+
+**AWS CDK (Node.js)**
+```js
+import * as lambda from "@aws-cdk/aws-lambda";
+
+const myLambda = new lambda.Function(this, "function-id", {
+  runtime: lambda.Runtime.NODEJS_12_X,
+  code: lambda.Code.fromAsset("lambda"),
+  handler: "index.handler",
+  functionName: "MyFunctionName", // Add this property to your Lambdas
+});
 ```

--- a/serverless/release.sh
+++ b/serverless/release.sh
@@ -109,7 +109,7 @@ else
     aws s3 cp template.yml s3://${BUCKET}/aws/serverless-macro-staging/latest.yml
 fi
 
-echo "Done uploading the template, and here is the CloudFormation quick launch URL"
-echo "https://console.aws.amazon.com/cloudformation/home#/stacks/quickCreate?stackName=datadog-serverless-macro&templateURL=${TEMPLATE_URL}"
+# echo "Done uploading the template, and here is the CloudFormation quick launch URL"
+# echo "https://console.aws.amazon.com/cloudformation/home#/stacks/quickCreate?stackName=datadog-serverless-macro&templateURL=${TEMPLATE_URL}"
 
 echo "Done!"

--- a/serverless/src/forwarder.ts
+++ b/serverless/src/forwarder.ts
@@ -5,11 +5,10 @@ import { Resources } from "./index";
 const LOG_GROUP_TYPE = "AWS::Logs::LogGroup";
 const SUBSCRIPTION_FILTER_TYPE = "AWS::Logs::SubscriptionFilter";
 const LAMBDA_LOG_GROUP_PREFIX = "/aws/lambda/";
-const LOG_GROUP = "LogGroup";
-const SUBSCRIPTION = "Subscription";
 const FN_SUB = "Fn::Sub";
 const FN_JOIN = "Fn::Join";
 const REF = "Ref";
+export const SUBSCRIPTION_FILTER_NAME = "datadog-serverless-macro-filter";
 
 export interface LogGroupDefinition {
   key: string;
@@ -37,6 +36,20 @@ export interface SubscriptionDefinition {
   subscriptionResource: SubscriptionResource;
 }
 
+export class MissingFunctionNameError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "MissingFunctionNameError";
+  }
+}
+
+export class MissingSubDeclarationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "MissingSubDeclarationError";
+  }
+}
+
 /**
  * To add the subscriptions for the provided forwarder ARN, we need the corresponding
  * log group for each lambda function.
@@ -48,6 +61,7 @@ export interface SubscriptionDefinition {
  * If no log group exists, then check if any are declared in the template (but not yet created).
  * If none are declared, we add a log group for the given lambda. In both cases, we also declare a
  * new subscription filter for the forwarder ARN on this log group.
+ * TODO: change comment
  */
 export async function addCloudWatchForwarderSubscriptions(
   resources: Resources,
@@ -60,11 +74,11 @@ export async function addCloudWatchForwarderSubscriptions(
   let logGroupsInTemplate: LogGroupDefinition[] | undefined;
   let subscriptionsInTemplate: SubscriptionDefinition[] | undefined;
   let functionNamePrefix: string;
-  let addSubscription: boolean;
 
   for (const lambda of lambdas) {
     let logGroup: CloudWatchLogs.LogGroup | undefined;
     let logGroupName: string | { [fn: string]: any } | undefined;
+    let logGroupKey: string | undefined;
 
     // If the lambda function has been run before, then a log group will already
     // exist, with a logGroupName property in the format '/aws/lambda/<function name>'
@@ -87,25 +101,23 @@ export async function addCloudWatchForwarderSubscriptions(
       if (logGroupsOnStack === undefined && stackName !== undefined) {
         logGroupsOnStack = await getExistingLambdaLogGroupsOnStack(cloudWatchLogs, stackName);
       }
-      if (logGroupsOnStack !== undefined) {
+      if (logGroupsOnStack) {
         logGroup = logGroupsOnStack.find(
           (lg) => lg.logGroupName && lg.logGroupName.startsWith(`${LAMBDA_LOG_GROUP_PREFIX}${stackName}-${lambda.key}`),
         );
       }
     }
 
-    // If there is a user declared log group/if this macro adds a log group declaration, save the logical id
-    // to add as a dependency. This prevents the subscription filter being created before the log group is.
-    // (Will stay undefined if a log group already exists, and will not be used.)
-    let logGroupKey: string | undefined;
-
     // If log group exists, we need to check if there are any existing subsciption filters.
     // We will only add a new subscription to the provided forwarder ARN if no current subscriptions exist.
-    if (logGroup !== undefined) {
-      // Since the log group exists in this case, the logGroupName must also be defined, since
+    if (logGroup) {
+      // The log group exists in this case, so the logGroupName must also be defined, since
       // that's the property we used to find this log group.
       logGroupName = logGroup.logGroupName as string;
-      addSubscription = await canSubscribeLogGroup(cloudWatchLogs, logGroupName, functionNamePrefix);
+      const canSub = await canSubscribeLogGroup(cloudWatchLogs, logGroupName, functionNamePrefix);
+      if (canSub) {
+        await putSubscriptionFilter(cloudWatchLogs, forwarderArn, logGroupName);
+      }
     } else {
       // If we were unable to find an existing log group, there are two more cases:
       // Either the user has declared a log group in their template explicitly, but has never
@@ -127,18 +139,30 @@ export async function addCloudWatchForwarderSubscriptions(
         }
         // If a log group has already been declared but not yet initialized, check if any
         // subscriptions are declared, so we don't overwrite them.
-        addSubscription = !isSubscriptionAlreadyDeclared(subscriptionsInTemplate, logGroupName, declaredLogGroup.key);
+        const declaredSub = findDeclareSub(subscriptionsInTemplate, logGroupName, logGroupKey);
+        if (declaredSub === undefined) {
+          throw new MissingSubDeclarationError(
+            `Found a declared log group for ${lambda.key} but no subscription filter declared for ${forwarderArn}. ` +
+              `To allow the macro to automatically create these for you, please remove the log group declaration.`,
+          );
+        }
       } else {
         // If there's no existing log group and none were declared in the template for this lambda,
-        // then we create a new log group by declaring one in the template.
-        logGroupKey = `${lambda.key}${LOG_GROUP}`;
-        logGroupName = addLogGroupToTemplate(resources, lambda, logGroupKey);
-        addSubscription = true;
+        // and the 'FunctionName' property exists, then we create a log group and subscription filter using AWS SDK.
+        // If the function name is dynamically generated, we cannot predict the randomly generated
+        // component, and will throw an error for the user to either add a function name or
+        // declare a log group in their CloudFormation stack.
+        if (lambda.properties.FunctionName) {
+          logGroupName = `${LAMBDA_LOG_GROUP_PREFIX}${lambda.properties.FunctionName}`;
+          await createLogGroup(cloudWatchLogs, logGroupName);
+          await putSubscriptionFilter(cloudWatchLogs, forwarderArn, logGroupName);
+        } else {
+          throw new MissingFunctionNameError(
+            `'FunctionName' property is undefined for ${lambda.key}, cannot create log group for CloudWatch subscriptions. ` +
+              `Please add 'FunctionName' for ${lambda.key} or declare a log group for this Lambda function in your stack.`,
+          );
+        }
       }
-    }
-
-    if (addSubscription) {
-      addSubscriptionToTemplate(resources, forwarderArn, lambda.key, logGroupName, logGroupKey);
     }
   }
 }
@@ -239,7 +263,7 @@ function findSubscriptionsInTemplate(resources: Resources) {
     });
 }
 
-function isSubscriptionAlreadyDeclared(
+function findDeclareSub(
   subscriptions: SubscriptionDefinition[],
   logGroupName: string | { [fn: string]: any },
   logGroupKey: string,
@@ -247,48 +271,25 @@ function isSubscriptionAlreadyDeclared(
   for (const subscription of subscriptions) {
     const subscribedLogGroupName = subscription.subscriptionResource.Properties.LogGroupName;
     if (typeof subscribedLogGroupName === "string" && subscribedLogGroupName.includes(logGroupKey)) {
-      return true;
+      return subscription;
     }
     if (subscribedLogGroupName === logGroupName) {
-      return true;
+      return subscription;
     }
   }
-  return false;
 }
 
-function addLogGroupToTemplate(resources: Resources, lambda: LambdaFunction, logGroupKey: string) {
-  // '${functionKey}' will either reference the FunctionName property if it exists,
-  // or the dynamically generated name
-  const logGroupName = {
-    "Fn::Sub": `${LAMBDA_LOG_GROUP_PREFIX}\${${lambda.key}}`,
+async function putSubscriptionFilter(cloudWatchLogs: CloudWatchLogs, forwarderArn: string, logGroupName: string) {
+  const args = {
+    destinationArn: forwarderArn,
+    filterName: SUBSCRIPTION_FILTER_NAME,
+    filterPattern: "",
+    logGroupName,
   };
-  resources[logGroupKey] = {
-    Type: LOG_GROUP_TYPE,
-    Properties: { LogGroupName: logGroupName },
-  };
-  return logGroupName;
+  await cloudWatchLogs.putSubscriptionFilter(args).promise();
 }
 
-function addSubscriptionToTemplate(
-  resources: Resources,
-  forwarderArn: string,
-  functionKey: string,
-  logGroupName: string | { [fn: string]: any },
-  logGroupKey: string | undefined,
-) {
-  const subscriptionName = `${functionKey}${LOG_GROUP}${SUBSCRIPTION}`;
-  const subscription: SubscriptionResource = {
-    Type: SUBSCRIPTION_FILTER_TYPE,
-    Properties: {
-      DestinationArn: forwarderArn,
-      FilterPattern: "",
-      LogGroupName: logGroupName,
-    },
-  };
-  // If a log group is declared in the template, reference the logical id of the log group
-  // to ensure that the subscription filter is created after the log group.
-  if (logGroupKey) {
-    subscription.DependsOn = logGroupKey;
-  }
-  resources[subscriptionName] = subscription;
+async function createLogGroup(cloudWatchLogs: CloudWatchLogs, logGroupName: string) {
+  const args = { logGroupName };
+  await cloudWatchLogs.createLogGroup(args).promise();
 }

--- a/serverless/template.yml
+++ b/serverless/template.yml
@@ -77,7 +77,9 @@ Resources:
             - Effect: Allow
               Action:
                 - logs:DescribeLogGroups
+                - logs:CreateLogGroup
                 - logs:DescribeSubscriptionFilters
+                - logs:PutSubscriptionFilter
               Resource: "*"
   MacroFunctionLogGroup:
     Type: AWS::Logs::LogGroup

--- a/serverless/tools/create_test_stack.sh
+++ b/serverless/tools/create_test_stack.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Tests installation and deployment process of macro, and that CloudFormation template works.
+set -e
+
+# Deploy the stack to a less commonly used region to avoid any problems with limits
+AWS_REGION="sa-east-1"
+
+# Move into the root directory, so this script can be called from any directory
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd $DIR/..
+
+CURRENT_VERSION="$(grep -o 'Version: \d\+\.\d\+\.\d\+' template.yml | cut -d' ' -f2)-test"
+
+# Make sure we aren't trying to do anything on Datadog's production account. We don't want our
+# integration tests to accidentally release a new version of the macro
+AWS_ACCOUNT="$(aws sts get-caller-identity --query Account --output text)"
+if [ "$AWS_ACCOUNT" = "464622532012" ] ; then
+    echo "Detected production credentials. Aborting"
+    exit 1
+fi
+
+# Run script in this process. This gives us TEMPLATE_URL and MACRO_SOURCE_URL env vars
+. release.sh datadog-cloudformation-template-staging $CURRENT_VERSION
+
+function param {
+    KEY=$1
+    VALUE=$2
+    echo "{\"ParameterKey\":\"${KEY}\",\"ParameterValue\":${VALUE}}"
+}
+
+PARAM_LIST=[$(param SourceZipUrl \"${MACRO_SOURCE_URL}\")]
+echo "Setting params ${PARAM_LIST}"
+
+# Create an instance of the stack
+STACK_NAME="serverless-macro-test-stack-${RUN_ID}"
+echo "Creating stack ${STACK_NAME}"
+aws cloudformation create-stack --stack-name $STACK_NAME --template-url $TEMPLATE_URL --capabilities "CAPABILITY_AUTO_EXPAND" "CAPABILITY_IAM" --on-failure "DELETE" \
+    --parameters=$PARAM_LIST --region $AWS_REGION
+
+echo "Waiting for stack to complete creation ${STACK_NAME}"
+aws cloudformation wait stack-create-complete --stack-name $STACK_NAME --region $AWS_REGION
+
+echo "Completed stack creation"

--- a/serverless/tools/create_test_stack.sh
+++ b/serverless/tools/create_test_stack.sh
@@ -33,7 +33,7 @@ PARAM_LIST=[$(param SourceZipUrl \"${MACRO_SOURCE_URL}\")]
 echo "Setting params ${PARAM_LIST}"
 
 # Create an instance of the stack
-STACK_NAME="serverless-macro-test-stack-${RUN_ID}"
+STACK_NAME="serverless-macro-test-stack"
 echo "Creating stack ${STACK_NAME}"
 aws cloudformation create-stack --stack-name $STACK_NAME --template-url $TEMPLATE_URL --capabilities "CAPABILITY_AUTO_EXPAND" "CAPABILITY_IAM" --on-failure "DELETE" \
     --parameters=$PARAM_LIST --region $AWS_REGION

--- a/serverless/tools/update_test_stack.sh
+++ b/serverless/tools/update_test_stack.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Usage: ./tools/update_test_stack.sh <stack-name>
+
+CURRENT_VERSION="$(grep -o 'Version: \d\+\.\d\+\.\d\+' template.yml | cut -d' ' -f2)-test"
+
+# Default test bucket used in ./tools/create_test_stach.sh
+BUCKET="datadog-cloudformation-template-staging"
+
+# Set template and macro URLs
+TEMPLATE_URL="https://${BUCKET}.s3.amazonaws.com/aws/serverless-macro-staging/latest.yml"
+MACRO_SOURCE_URL="s3://${BUCKET}/aws/serverless-macro-staging-zip/serverless-macro-${CURRENT_VERSION}.zip"
+
+# Match the region that ./tools/create_test_stack.sh uses
+AWS_REGION="sa-east-1"
+
+# Move into the root directory, so this script can be called from any directory
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd $DIR/..
+
+# Read the stack to update
+if [ -z "$1" ]; then
+    echo "Must specify a stack to update"
+    exit 1
+else
+    STACK_NAME=$1
+fi
+
+# Make a deployment for this stack
+echo "Updating stack ${STACK_NAME}"
+aws cloudformation update_stack --stack-name $STACK_NAME --template-url $TEMPLATE_URL --capabilities "CAPABILITY_AUTO_EXPAND" "CAPABILITY_IAM" \
+    --parameters=$PARAM_LIST --region $AWS_REGION
+
+echo "Waiting for stack to complete update for ${STACK_NAME}"
+aws cloudformation wait stack-update-complete --stack-name $STACK_NAME --region $AWS_REGION
+
+echo "Completed stack update"

--- a/serverless/tools/update_test_stack.sh
+++ b/serverless/tools/update_test_stack.sh
@@ -2,21 +2,7 @@
 
 # Usage: ./tools/update_test_stack.sh <stack-name>
 
-CURRENT_VERSION="$(grep -o 'Version: \d\+\.\d\+\.\d\+' template.yml | cut -d' ' -f2)-test"
-
-# Default test bucket used in ./tools/create_test_stach.sh
-BUCKET="datadog-cloudformation-template-staging"
-
-# Set template and macro URLs
-TEMPLATE_URL="https://${BUCKET}.s3.amazonaws.com/aws/serverless-macro-staging/latest.yml"
-MACRO_SOURCE_URL="s3://${BUCKET}/aws/serverless-macro-staging-zip/serverless-macro-${CURRENT_VERSION}.zip"
-
-# Match the region that ./tools/create_test_stack.sh uses
-AWS_REGION="sa-east-1"
-
-# Move into the root directory, so this script can be called from any directory
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-cd $DIR/..
+set -e
 
 # Read the stack to update
 if [ -z "$1" ]; then
@@ -26,9 +12,41 @@ else
     STACK_NAME=$1
 fi
 
+# Match the region that ./tools/create_test_stack.sh uses
+AWS_REGION="sa-east-1"
+
+# Move into the root directory, so this script can be called from any directory
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd $DIR/..
+
+CURRENT_VERSION="$(grep -o 'Version: \d\+\.\d\+\.\d\+' template.yml | cut -d' ' -f2)-test"
+
+# Make sure we aren't trying to do anything on Datadog's production account. We don't want our
+# integration tests to accidentally release a new version of the macro
+AWS_ACCOUNT="$(aws sts get-caller-identity --query Account --output text)"
+if [ "$AWS_ACCOUNT" = "464622532012" ] ; then
+    echo "Detected production credentials. Aborting"
+    exit 1
+fi
+
+# Default test bucket used in ./tools/create_test_stack.sh
+BUCKET="datadog-cloudformation-template-staging"
+
+# Run script in this process. This gives us TEMPLATE_URL and MACRO_SOURCE_URL env vars
+. release.sh $BUCKET $CURRENT_VERSION
+
+function param {
+    KEY=$1
+    VALUE=$2
+    echo "{\"ParameterKey\":\"${KEY}\",\"ParameterValue\":${VALUE}}"
+}
+
+echo "Setting params ${PARAM_LIST}"
+PARAM_LIST=[$(param SourceZipUrl \"${MACRO_SOURCE_URL}\")]
+
 # Make a deployment for this stack
 echo "Updating stack ${STACK_NAME}"
-aws cloudformation update_stack --stack-name $STACK_NAME --template-url $TEMPLATE_URL --capabilities "CAPABILITY_AUTO_EXPAND" "CAPABILITY_IAM" \
+aws cloudformation update-stack --stack-name $STACK_NAME --template-url $TEMPLATE_URL --capabilities "CAPABILITY_AUTO_EXPAND" "CAPABILITY_IAM" \
     --parameters=$PARAM_LIST --region $AWS_REGION
 
 echo "Waiting for stack to complete update for ${STACK_NAME}"


### PR DESCRIPTION
### What does this PR do?

For customers who provide `forwarderArn`, create log groups and subscription filters through AWS SDK `createLogGroup` and `putSubscriptionFilter` instead of adding declarations to the CloudFormation template.

### Motivation

Currently, customers who are deploying their Lambdas for the first time will run into potential issues in later deployments. When the macro creates a log group and subscription filter by adding declarations to the template, this works fine the first time, but for later deployments, applying the macro again will result in those resources being deleted. This is because we currently have no way to determine which log groups were created by the macro. (If a log group was created by a macro in a previous iteration, we should add the declaration again to make sure it doesn't get removed.) This solution removes template declarations and uses AWS SDK to create these resources.

Limitation: using the AWS SDK to create the log group requires customers to provide the optional `FunctionName` parameter.
For more details, see the [Jira ticket](https://datadoghq.atlassian.net/browse/SLS-683).

### Testing Guidelines

Modified unit tests and tested with deployments for both SAM and CDK in sandbox account.

### Types of changes

- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)
