### PR TITLE
Use change set to deploy changes after new release

### DIFF
--- a/serverless/README.md
+++ b/serverless/README.md
@@ -14,12 +14,17 @@ aws cloudformation create-stack \
   --capabilities CAPABILITY_AUTO_EXPAND CAPABILITY_IAM
 ```
 
-If you are updating the macro after a new release, use the `update-stack` method instead with the same paramters:
+If you are updating the macro after a new release, create and execute a change set with the updated template:
 ```bash
-aws cloudformation update-stack \
+aws cloudformation create-change-set \
   --stack-name datadog-serverless-macro \
   --template-url https://datadog-cloudformation-template.s3.amazonaws.com/aws/serverless-macro/latest.yml \
-  --capabilities CAPABILITY_AUTO_EXPAND CAPABILITY_IAM
+  --capabilities CAPABILITY_AUTO_EXPAND CAPABILITY_IAM \
+  --change-set-name datadog-serverless-macro-<newest release version>
+
+aws cloudformation execute-change-set \
+  --stack-name datadog-serverless-macro \
+  --change-set-name datadog-serverless-macro-<newest release version>
 ```
 
 **Note:** You only need to deploy the macro once for a given region in your account, and it can be used for all CloudFormation stacks deployed in that same region.

--- a/serverless/local_test_template.yml
+++ b/serverless/local_test_template.yml
@@ -1,0 +1,39 @@
+# Usage:
+# aws cloudformation package \
+#   --template-file local_test_template.yml \
+#   --s3-bucket <s3 bucket name here> \
+#   --output-template-file packaged.template
+
+# aws cloudformation deploy \
+#   --stack-name serverless-macro-test-stack \
+#   --template-file packaged.template \
+#   --capabilities CAPABILITY_IAM
+
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: AWS::Serverless-2016-10-31
+Description: Template for testing local changes, can be deployed directly without creating zip file or using ZipCopier in template.yml
+
+Resources:
+  Function:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: dist
+      Handler: index.handler
+      Runtime: nodejs12.x
+      Policies:
+        - Statement:
+            - Effect: Allow
+              Action:
+                - logs:DescribeLogGroups
+                - logs:DescribeSubscriptionFilters
+                - logs:CreateLogGroup
+                - logs:PutSubscriptionFilter
+              Resource: "*"
+  Macro:
+    Type: AWS::CloudFormation::Macro
+    Properties:
+      Name: DatadogServerless
+      FunctionName:
+        Fn::GetAtt:
+          - Function
+          - Arn

--- a/serverless/tools/create_test_stack.sh
+++ b/serverless/tools/create_test_stack.sh
@@ -10,7 +10,9 @@ AWS_REGION="sa-east-1"
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd $DIR/..
 
-CURRENT_VERSION="$(grep -o 'Version: \d\+\.\d\+\.\d\+' template.yml | cut -d' ' -f2)-test"
+RUN_ID=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c10)
+
+CURRENT_VERSION="$(grep -o 'Version: \d\+\.\d\+\.\d\+' template.yml | cut -d' ' -f2)-test-${RUN_ID}"
 
 # Make sure we aren't trying to do anything on Datadog's production account. We don't want our
 # integration tests to accidentally release a new version of the macro
@@ -33,7 +35,7 @@ PARAM_LIST=[$(param SourceZipUrl \"${MACRO_SOURCE_URL}\")]
 echo "Setting params ${PARAM_LIST}"
 
 # Create an instance of the stack
-STACK_NAME="serverless-macro-test-stack"
+STACK_NAME="serverless-macro-test-stack-${RUN_ID}"
 echo "Creating stack ${STACK_NAME}"
 aws cloudformation create-stack --stack-name $STACK_NAME --template-url $TEMPLATE_URL --capabilities "CAPABILITY_AUTO_EXPAND" "CAPABILITY_IAM" --on-failure "DELETE" \
     --parameters=$PARAM_LIST --region $AWS_REGION


### PR DESCRIPTION
### What does this PR do?

* replaces `update-stack` with `create-change-set` and `execute-change-set` so users can apply changes to macro upon new release
* modifies `create_test_stack` and `update_test_stack` scripts (used for testing) to use change sets to update stack
* adds simplified template for quick testing; can deploy without the zip copier method that's used to distribute to customers
(usage for test scripts and simplified template documented on [wiki page](https://github.com/DataDog/devops/wiki/Datadog-CloudFormation-Macro))

### Motivation

The `update-stack` cli method does not create a change set for the CloudFormation stack, so customers will not be able to get the changes we've made in new releases based on the current instructions. To make sure changes are deployed, users will need to create and execute a change set instead.

### Testing Guidelines

Used scripts `./tools/create_test_stack.sh` and `./tools/update_test_stack.sh` to test new method of updating with change sets.

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)
