### PR TITLE
PermissionsBoundaryArn for MacroFunctionZipCopier

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,7 @@ Make your change, update tests and ensure the tests pass.
 For the Datadog Serverless Macro:
 ```bash
 cd serverless
+yarn install
 yarn test
 ```
 

--- a/serverless/README.md
+++ b/serverless/README.md
@@ -14,7 +14,7 @@ aws cloudformation create-stack \
   --capabilities CAPABILITY_AUTO_EXPAND CAPABILITY_IAM
 ```
 
-If you are updating the macro after a new release, use the `update-stack` method instead with the same paramters:
+If you are updating the macro after a new release, use the `update-stack` method instead with the same parameters:
 ```bash
 aws cloudformation update-stack \
   --stack-name datadog-serverless-macro \
@@ -28,7 +28,7 @@ aws cloudformation update-stack \
 
 ### AWS SAM
 
-If you are deploying your serverless application with SAM, add the Datadog Serverless CloudFormation macro under the `Transform` section in your your `template.yml` file, after the required SAM transform:
+If you are deploying your serverless application with SAM, add the Datadog Serverless CloudFormation macro under the `Transform` section in your `template.yml` file, after the required SAM transform:
 
 ```yaml
 Transform:
@@ -171,10 +171,10 @@ class CdkStack(core.Stack):
     super().__init__(scope, id, **kwargs)
     self.add_transform("DatadogServerless")
 
-    mapping = core.CfnMapping(self, "Datadog", # The id for this CfnMapping must be 'Datadog'
+    core.CfnMapping(self, "Datadog", # The id for this CfnMapping must be 'Datadog'
       mapping={
         "Parameters": { # This mapping key must be 'Parameters'
-          "nodeLayerVersion": 25,
+          "pythonLayerVersion": 19,
           "forwarderArn": "arn:aws:lambda:us-east-1:000000000000:function:datadog-forwarder",
           "stackName": self.stackName,
           "service": "service-name",

--- a/serverless/template.yml
+++ b/serverless/template.yml
@@ -181,6 +181,11 @@ Resources:
                 send_cfn_resp(event, context, 'SUCCESS')
             finally:
                 timer.cancel()
+      PermissionsBoundary:
+        Fn::If:
+          - SetPermissionsBoundary
+          - Ref: PermissionsBoundaryArn
+          - Ref: AWS::NoValue
       Policies:
         - Version: "2012-10-17"
           Statement:


### PR DESCRIPTION
### What does this PR do?

Add `PermissionsBoundaryArn` parameter support for `MacroFunctionZipCopier` function's roles
Small fixes in `README.md` file

### Motivation

All our roles should have permission boundaries

### Testing Guidelines

run local tests (yarn test) + deployed and tested `serverless/template.yaml` on our environment

### Types of changes

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [X] Misc (docs, refactoring, dependency upgrade, etc.)