### PR TITLE
Adds option to use the GovCloud lambda layer

### DIFF
--- a/serverless/README.md
+++ b/serverless/README.md
@@ -79,6 +79,7 @@ To further configure your plugin, use the following custom parameters in your `s
 | `addLayers`             | Whether to add the Lambda Layers or expect the user to bring their own. Defaults to true. When true, the Lambda Library version variables are also required. When false, you must include the Datadog Lambda library in your functions' deployment packages.                                                                                                                                                                                                                                    |
 | `pythonLayerVersion`    | Version of the Python Lambda layer to install, such as "21". Required if you are deploying at least one Lambda function written in Python and `addLayers` is true. Find the latest version number from [https://github.com/DataDog/datadog-lambda-python/releases][5].                                                                                                                                                                                                                           |
 | `nodeLayerVersion`      | Version of the Node.js Lambda layer to install, such as "29". Required if you are deploying at least one Lambda function written in Node.js and `addLayers` is true. Find the latest version number from [https://github.com/DataDog/datadog-lambda-js/releases][6].                                                                                                                                                                                                                             |
+| `isGovCloud`            | Whether your function is running in GovCloud. Defaults to false. When true, it attaches the GovCloud Lambda layer to your functions.                                                                                                                                                                                                                    |
 | `forwarderArn:`         | When set, the plugin will automatically subscribe the functions' log groups to the Datadog Forwarder. Alternatively, you can define the log subscription using the `AWS::Logs::SubscriptionFilter` resource. **Note**: The 'FunctionName' property must be defined for functions that are deployed for the first time because the macro needs the function name to create the log groups and subscription filters. 'FunctionName' must NOT contain any CloudFormation functions, such as `!Sub`. |
 | `stackName`             | The name of the CloudFormation stack being deployed. Only required when a `forwarderArn` is provided and Lambda functions are dynamically named (when the `FunctionName` property isn't provided for a Lambda). For more information on how to add this parameter for SAM and CDK, see the examples below.                                                                                                                                                                                           |
 | `flushMetricsToLogs`    | Send custom metrics via logs with the Datadog Forwarder Lambda function (recommended). Defaults to `true`. When set to `false`, the Datadog API key must be defined using `apiKey` or `apiKMSKey`.                                                                                                                                                                                                                                                                                       |
@@ -122,7 +123,7 @@ To configure this library in SAM, add the following section to the `Parameters` 
 Transform:
   - AWS::Serverless-2016-10-31
   - Name: DatadogServerless
-    Parameters: 
+    Parameters:
         nodeLayerVersion: 25
         forwarderArn: "arn:aws:lambda:us-east-1:000000000000:function:datadog-forwarder"
         stackName: !Ref "AWS::StackName"
@@ -132,7 +133,7 @@ Transform:
 
 ### AWS CDK
 
-To configure the library when deploying with CDK, add a `CfnMapping` to your `Stack` object: 
+To configure the library when deploying with CDK, add a `CfnMapping` to your `Stack` object:
 
 **Typescript**
 ```typescript
@@ -254,7 +255,7 @@ const subscription = new CfnSubscriptionFilter(this, `DatadogForwarderSubscripti
 
 ### Error message: 'logGroupNamePrefix' failed to satisfy constraint...
 
-The `forwarderArn` option does not work when `FunctionName` contains CloudFormation functions, such as `!Sub`. In this case, the macro does not have access to the actual function name (CloudFormation executes functions after transformations). It therefore cannot create log groups and subscription filters for your functions. 
+The `forwarderArn` option does not work when `FunctionName` contains CloudFormation functions, such as `!Sub`. In this case, the macro does not have access to the actual function name (CloudFormation executes functions after transformations). It therefore cannot create log groups and subscription filters for your functions.
 
 Remove the `forwarderArn` parameter from the SAM template or CDK source code, and instead define the subscription filters using the [AWS::Logs::SubscriptionFilter][7] resource like below.
 

--- a/serverless/src/env.ts
+++ b/serverless/src/env.ts
@@ -7,6 +7,8 @@ export interface Configuration {
   pythonLayerVersion?: number;
   // Node.js Lambda layer version
   nodeLayerVersion?: number;
+  // Whether this is deployed in GovCloud so the GovCloud lambda layer can be applied
+  isGovCloud?: boolean;
   // Datadog API Key, only necessary when using metrics without log forwarding
   apiKey?: string;
   // Datadog API Key encrypted using KMS, only necessary when using metrics without log forwarding

--- a/serverless/src/index.ts
+++ b/serverless/src/index.ts
@@ -65,7 +65,13 @@ export const handler = async (event: InputEvent, _: any) => {
 
     // Apply layers
     if (config.addLayers) {
-      const errors = applyLayers(region, lambdas, config.pythonLayerVersion, config.nodeLayerVersion, config.isGovCloud);
+      const errors = applyLayers(
+        region,
+        lambdas,
+        config.pythonLayerVersion,
+        config.nodeLayerVersion,
+        config.isGovCloud,
+      );
       if (errors.length > 0) {
         return {
           requestId: event.requestId,

--- a/serverless/src/index.ts
+++ b/serverless/src/index.ts
@@ -65,7 +65,7 @@ export const handler = async (event: InputEvent, _: any) => {
 
     // Apply layers
     if (config.addLayers) {
-      const errors = applyLayers(region, lambdas, config.pythonLayerVersion, config.nodeLayerVersion);
+      const errors = applyLayers(region, lambdas, config.pythonLayerVersion, config.nodeLayerVersion, config.isGovCloud);
       if (errors.length > 0) {
         return {
           requestId: event.requestId,

--- a/serverless/test/index.spec.ts
+++ b/serverless/test/index.spec.ts
@@ -99,7 +99,7 @@ function mockInputEvent(params: any, mappings: any, logGroups?: LogGroupDefiniti
 }
 
 function mockGovCloudInputEvent(params: any, mappings: any, logGroups?: LogGroupDefinition[]) {
-  let govCloudEvent = mockInputEvent(params, mappings, logGroups);
+  const govCloudEvent = mockInputEvent(params, mappings, logGroups);
   govCloudEvent.region = "us-gov-east-1";
   return govCloudEvent;
 }

--- a/serverless/test/index.spec.ts
+++ b/serverless/test/index.spec.ts
@@ -98,6 +98,12 @@ function mockInputEvent(params: any, mappings: any, logGroups?: LogGroupDefiniti
   } as InputEvent;
 }
 
+function mockGovCloudInputEvent(params: any, mappings: any, logGroups?: LogGroupDefinition[]) {
+  let govCloudEvent = mockInputEvent(params, mappings, logGroups);
+  govCloudEvent.region = "us-gov-east-1";
+  return govCloudEvent;
+}
+
 describe("Macro", () => {
   describe("parameters and config", () => {
     it("uses transform parameters if they are provided", async () => {
@@ -160,6 +166,17 @@ describe("Macro", () => {
       const lambdaProperties: FunctionProperties = output.fragment.Resources[LAMBDA_KEY].Properties;
 
       expect(lambdaProperties.Layers).toBeUndefined();
+    });
+
+    it("uses the govcloud layer when isGovCloud is true", async () => {
+      const params = { isGovCloud: true, nodeLayerVersion: 25 };
+      const inputEvent = mockGovCloudInputEvent(params, {});
+      const output = await handler(inputEvent, {});
+      const lambdaProperties: FunctionProperties = output.fragment.Resources[LAMBDA_KEY].Properties;
+
+      expect(lambdaProperties.Layers).toEqual([
+        expect.stringMatching(/arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Node12-x:25/),
+      ]);
     });
   });
 

--- a/serverless/test/layer.spec.ts
+++ b/serverless/test/layer.spec.ts
@@ -4,6 +4,7 @@ import {
   RuntimeType,
   applyLayers,
   DD_ACCOUNT_ID,
+  DD_GOV_ACCOUNT_ID,
   getMissingLayerVersionErrorMsg,
 } from "../src/layer";
 
@@ -125,5 +126,21 @@ describe("applyLayers", () => {
     ]);
     expect(pythonLambda.properties.Layers).toBeUndefined();
     expect(nodeLambda.properties.Layers).toBeUndefined();
+  });
+});
+
+describe("isGovCloud", () => {
+  it("applies the GovCloud layer", () => {
+    const pythonLambda = mockLambdaFunction("PythonFunctionKey", "python3.8", RuntimeType.PYTHON);
+    const nodeLambda = mockLambdaFunction("NodeFunctionKey", "nodejs10.x", RuntimeType.NODE);
+    const errors = applyLayers("us-gov-east-1", [pythonLambda, nodeLambda], 21, 30, true);
+
+    expect(errors.length).toEqual(0);
+    expect(pythonLambda.properties.Layers).toEqual([
+      `arn:aws-us-gov:lambda:us-gov-east-1:${DD_GOV_ACCOUNT_ID}:layer:Datadog-Python38:21`,
+    ]);
+    expect(nodeLambda.properties.Layers).toEqual([
+      `arn:aws-us-gov:lambda:us-gov-east-1:${DD_GOV_ACCOUNT_ID}:layer:Datadog-Node10-x:30`,
+    ]);
   });
 });


### PR DESCRIPTION
### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->
Adds the parameter of `isGovCloud` to have the GovCloud lambda layer be added to the user's functions.

### Motivation

<!--- What inspired you to submit this pull request? --->
SLS-701 - the GovCloud layer has a different ARN to be accounted for.

### Testing Guidelines

<!--- How did you test this pull request? --->
Added new unit tests to cover this case.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
