### PR TITLE
[serverless] Tag lambdas provisioned with CDK

### DIFF
--- a/serverless/src/index.ts
+++ b/serverless/src/index.ts
@@ -1,7 +1,7 @@
 import { getConfigFromCfnMappings, getConfigFromCfnParams, setEnvConfiguration } from "./env";
 import { findLambdas, applyLayers, LambdaFunction } from "./layer";
 import { getTracingMode, enableTracing, MissingIamRoleError } from "./tracing";
-import { addServiceAndEnvTags, addMacroTag } from "./tags";
+import { addServiceAndEnvTags, addMacroTag, addCDKTag } from "./tags";
 import { redirectHandlers } from "./redirect";
 import { addCloudWatchForwarderSubscriptions } from "./forwarder";
 import { CloudWatchLogs } from "aws-sdk";
@@ -121,6 +121,10 @@ export const handler = async (event: InputEvent, _: any) => {
     }
 
     addMacroTag(lambdas, version);
+
+    if (resources.CDKMetadata) {
+      addCDKTag(lambdas);
+    }
 
     // Redirect handlers
     redirectHandlers(lambdas, config.addLayers);

--- a/serverless/src/index.ts
+++ b/serverless/src/index.ts
@@ -1,7 +1,7 @@
 import { getConfigFromCfnMappings, getConfigFromCfnParams, setEnvConfiguration } from "./env";
 import { findLambdas, applyLayers, LambdaFunction } from "./layer";
 import { getTracingMode, enableTracing, MissingIamRoleError } from "./tracing";
-import { addServiceAndEnvTags, addMacroTag, addCDKTag } from "./tags";
+import { addServiceAndEnvTags, addMacroTag, addCDKTag, addSAMTag } from "./tags";
 import { redirectHandlers } from "./redirect";
 import { addCloudWatchForwarderSubscriptions } from "./forwarder";
 import { CloudWatchLogs } from "aws-sdk";
@@ -124,6 +124,8 @@ export const handler = async (event: InputEvent, _: any) => {
 
     if (resources.CDKMetadata) {
       addCDKTag(lambdas);
+    } else {
+      addSAMTag(lambdas);
     }
 
     // Redirect handlers

--- a/serverless/src/tags.ts
+++ b/serverless/src/tags.ts
@@ -4,7 +4,7 @@ const SERVICE = "service";
 const ENV = "env";
 const MACRO_VERSION = "dd_sls_macro";
 // Following the same pattern from SAM
-const LAMBDA_CREATED = "lambda:createdBy";
+const MACRO_BY = "dd_sls_macro_by";
 
 export function addServiceAndEnvTags(lambdas: LambdaFunction[], service: string | undefined, env: string | undefined) {
   // Add the tag for each function, unless a 'service' or 'env' tag already exists.
@@ -49,7 +49,20 @@ export function addMacroTag(lambdas: LambdaFunction[], version: string | undefin
 export function addCDKTag(lambdas: LambdaFunction[]) {
   lambdas.forEach((lambda) => {
     const tags = lambda.properties.Tags ?? [];
-    tags.push({ Value: `CDK`, Key: LAMBDA_CREATED });
+    tags.push({ Value: 'CDK', Key: MACRO_BY });
+
+    lambda.properties.Tags = tags;
+  });
+}
+
+export function addSAMTag(lambdas: LambdaFunction[]) {
+  lambdas.forEach((lambda) => {
+    const tags = lambda.properties.Tags ?? [];
+    tags.forEach(tag => {
+      if (tag.Key === 'lambda:createdBy' && tag.Value === 'SAM') {
+        tags.push({ Value: `SAM`, Key: MACRO_BY });
+      }
+    })
 
     lambda.properties.Tags = tags;
   });

--- a/serverless/src/tags.ts
+++ b/serverless/src/tags.ts
@@ -3,6 +3,8 @@ import { LambdaFunction } from "./layer";
 const SERVICE = "service";
 const ENV = "env";
 const MACRO_VERSION = "dd_sls_macro";
+// Following the same pattern from SAM
+const LAMBDA_CREATED = "lambda:createdBy";
 
 export function addServiceAndEnvTags(lambdas: LambdaFunction[], service: string | undefined, env: string | undefined) {
   // Add the tag for each function, unless a 'service' or 'env' tag already exists.
@@ -39,6 +41,15 @@ export function addMacroTag(lambdas: LambdaFunction[], version: string | undefin
   lambdas.forEach((lambda) => {
     const tags = lambda.properties.Tags ?? [];
     tags.push({ Value: `v${version}`, Key: MACRO_VERSION });
+
+    lambda.properties.Tags = tags;
+  });
+}
+
+export function addCDKTag(lambdas: LambdaFunction[]) {
+  lambdas.forEach((lambda) => {
+    const tags = lambda.properties.Tags ?? [];
+    tags.push({ Value: `CDK`, Key: LAMBDA_CREATED });
 
     lambda.properties.Tags = tags;
   });

--- a/serverless/src/tags.ts
+++ b/serverless/src/tags.ts
@@ -49,7 +49,7 @@ export function addMacroTag(lambdas: LambdaFunction[], version: string | undefin
 export function addCDKTag(lambdas: LambdaFunction[]) {
   lambdas.forEach((lambda) => {
     const tags = lambda.properties.Tags ?? [];
-    tags.push({ Value: 'CDK', Key: MACRO_BY });
+    tags.push({ Value: "CDK", Key: MACRO_BY });
 
     lambda.properties.Tags = tags;
   });
@@ -58,11 +58,11 @@ export function addCDKTag(lambdas: LambdaFunction[]) {
 export function addSAMTag(lambdas: LambdaFunction[]) {
   lambdas.forEach((lambda) => {
     const tags = lambda.properties.Tags ?? [];
-    tags.forEach(tag => {
-      if (tag.Key === 'lambda:createdBy' && tag.Value === 'SAM') {
+    tags.forEach((tag) => {
+      if (tag.Key === "lambda:createdBy" && tag.Value === "SAM") {
         tags.push({ Value: `SAM`, Key: MACRO_BY });
       }
-    })
+    });
 
     lambda.properties.Tags = tags;
   });

--- a/serverless/test/index.spec.ts
+++ b/serverless/test/index.spec.ts
@@ -40,7 +40,13 @@ jest.mock("aws-sdk", () => {
   };
 });
 
-function mockInputEvent(params: any, mappings: any, logGroups?: LogGroupDefinition[], fromCDK?: boolean, fromSAM?: boolean) {
+function mockInputEvent(
+  params: any,
+  mappings: any,
+  logGroups?: LogGroupDefinition[],
+  fromCDK?: boolean,
+  fromSAM?: boolean,
+) {
   const fragment: Record<string, any> = {
     AWSTemplateFormatVersion: "2010-09-09",
     Description: "Sample lambda with SAM and Datadog macro",
@@ -100,10 +106,12 @@ function mockInputEvent(params: any, mappings: any, logGroups?: LogGroupDefiniti
   }
 
   if (fromSAM) {
-    fragment.Resources.HelloWorldFunction.Properties.Tags = [{
-      Key: "lambda:createdBy",
-      Value: "SAM",
-    }];
+    fragment.Resources.HelloWorldFunction.Properties.Tags = [
+      {
+        Key: "lambda:createdBy",
+        Value: "SAM",
+      },
+    ];
   }
 
   return {

--- a/serverless/test/tags.spec.ts
+++ b/serverless/test/tags.spec.ts
@@ -1,5 +1,5 @@
 import { RuntimeType, LambdaFunction } from "../src/layer";
-import { addServiceAndEnvTags, addMacroTag, addCDKTag } from "../src/tags";
+import { addServiceAndEnvTags, addMacroTag, addCDKTag, addSAMTag } from "../src/tags";
 
 function mockLambdaFunction(tags: any) {
   return {
@@ -89,7 +89,7 @@ describe("addCDKTag", () => {
     const lambda = mockLambdaFunction(undefined);
     addCDKTag([lambda]);
 
-    expect(lambda.properties.Tags).toEqual([{ Value: "CDK", Key: "lambda:createdBy" }]);
+    expect(lambda.properties.Tags).toEqual([{ Value: "CDK", Key: "dd_sls_macro_by" }]);
   });
 
   it("appends version tag if needed", () => {
@@ -99,7 +99,27 @@ describe("addCDKTag", () => {
 
     expect(lambda.properties.Tags).toEqual([
       { Value: "dev", Key: "env" },
-      { Value: "CDK", Key: "lambda:createdBy" },
+      { Value: "CDK", Key: "dd_sls_macro_by" },
+    ]);
+  });
+});
+
+describe("addSAMTag", () => {
+  it("creates tags property if needed", () => {
+    const lambda = mockLambdaFunction(undefined);
+    addSAMTag([lambda]);
+
+    expect(lambda.properties.Tags).toEqual([]);
+  });
+
+  it("appends version tag if needed", () => {
+    const existingTags = [{ Value: "SAM", Key: "lambda:createdBy" }];
+    const lambda = mockLambdaFunction(existingTags);
+    addSAMTag([lambda]);
+
+    expect(lambda.properties.Tags).toEqual([
+      { Value: "SAM", Key: "lambda:createdBy" },
+      { Value: "SAM", Key: "dd_sls_macro_by" },
     ]);
   });
 });

--- a/serverless/test/tags.spec.ts
+++ b/serverless/test/tags.spec.ts
@@ -1,5 +1,5 @@
 import { RuntimeType, LambdaFunction } from "../src/layer";
-import { addServiceAndEnvTags, addMacroTag } from "../src/tags";
+import { addServiceAndEnvTags, addMacroTag, addCDKTag } from "../src/tags";
 
 function mockLambdaFunction(tags: any) {
   return {
@@ -80,6 +80,26 @@ describe("addMacroTag", () => {
     expect(lambda.properties.Tags).toEqual([
       { Value: "dev", Key: "env" },
       { Value: "v6.6.6", Key: "dd_sls_macro" },
+    ]);
+  });
+});
+
+describe("addCDKTag", () => {
+  it("creates tags property if needed", () => {
+    const lambda = mockLambdaFunction(undefined);
+    addCDKTag([lambda]);
+
+    expect(lambda.properties.Tags).toEqual([{ Value: "CDK", Key: "lambda:createdBy" }]);
+  });
+
+  it("appends version tag if needed", () => {
+    const existingTags = [{ Value: "dev", Key: "env" }];
+    const lambda = mockLambdaFunction(existingTags);
+    addCDKTag([lambda]);
+
+    expect(lambda.properties.Tags).toEqual([
+      { Value: "dev", Key: "env" },
+      { Value: "CDK", Key: "lambda:createdBy" },
     ]);
   });
 });


### PR DESCRIPTION
### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->
Adds a tag `lambda:createdBy` with the value `CDK` for lambdas that are provisioned with the AWS CDK. It follows the same tag key as `SAM`

### Motivation
Serverless telemetry
<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
- Manually tested
![](https://p-qKFgO2.t2.n0.cdn.getcloudapp.com/items/qGuvrnkw/Image%202020-10-21%20at%2012.23.48%20PM.png?v=8658fe621f9edaaf2c2d85e5856762d2)
- Unit tested

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [X] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [X] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [X] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
