### PR TITLE
Revert datadog links

### DIFF
--- a/serverless/package.json
+++ b/serverless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datadog-serverless-macro",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Cloudformation macro to automatically instrument python and node functions with datadog tracing",
   "repository": "https://github.com/DataDog/datadog-cloudformation-macro",
   "author": "Datadog",

--- a/serverless/src/index.ts
+++ b/serverless/src/index.ts
@@ -17,19 +17,9 @@ export interface Resources {
   };
 }
 
-interface Outputs {
-  [key: string]: {
-    Description: string;
-    Value: {
-      [Fn: string]: string;
-    };
-  };
-}
-
 interface CfnTemplate {
   Mappings?: any;
   Resources: Resources;
-  Outputs: Outputs;
 }
 
 export interface InputEvent {
@@ -60,7 +50,6 @@ export const handler = async (event: InputEvent, _: any) => {
     const fragment = event.fragment;
     const resources = fragment.Resources;
     const lambdas = findLambdas(resources);
-    const outputs = fragment.Outputs;
 
     let config;
 
@@ -142,9 +131,6 @@ export const handler = async (event: InputEvent, _: any) => {
     // Redirect handlers
     redirectHandlers(lambdas, config.addLayers);
 
-    // Add Output Links to Datadog Function
-    addOutputLinks(outputs, lambdas, config.site);
-
     return {
       requestId: event.requestId,
       status: SUCCESS,
@@ -173,25 +159,6 @@ function lambdaHasDynamicallyGeneratedName(lambdas: LambdaFunction[]) {
     }
   }
   return dynmicallyNamedLambdas;
-}
-
-/**
- * Builds the CloudFormation Outputs containing the alphanumeric key, description,
- * and value (URL) to the function in Datadog
- */
-function addOutputLinks(outputs: Outputs, lambdas: LambdaFunction[], site: string) {
-  for (const lambda of lambdas) {
-    const functionKey = lambda.key;
-    const key = `DatadogServerless${functionKey}`.replace(/[^a-z0-9]/gi, "");
-    // Create Fn::Sub string using the Logical ID of the function and AWS::Region/AccountId pseudoparameters
-    // https://app.datadoghq.com/functions/${LogicalID}:${AWS::Region}:${AWS::AccountId}:aws?source=cfn-macro
-    outputs[key] = {
-      Description: `Monitor ${functionKey} in Datadog:`,
-      Value: {
-        "Fn::Sub": `https://app.${site}/functions/\${${functionKey}}:\${AWS::Region}:\${AWS::AccountId}:aws?source=cfn-macro`,
-      },
-    };
-  }
 }
 
 export function getMissingStackNameErrorMsg(lambdaKeys: string[]) {

--- a/serverless/template.yml
+++ b/serverless/template.yml
@@ -4,7 +4,7 @@ Transform: AWS::Serverless-2016-10-31
 Mappings:
   Constants:
     DatadogServerlessMacro:
-      Version: 0.1.4
+      Version: 0.1.5
 
 Parameters:
   FunctionName:


### PR DESCRIPTION
### What does this PR do?

Reverts #20, as it seems to cause the cloudformation macro to throw an error sometimes. We're still working on identifying when and why that error happens.

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
