### PR TITLE
CloudFormation Macro support for two Cloudwatch log group subscription filters

### DIFF
--- a/serverless/src/forwarder.ts
+++ b/serverless/src/forwarder.ts
@@ -209,9 +209,8 @@ export async function getExistingLambdaLogGroupsOnStack(cloudWatchLogs: CloudWat
 
 export async function shouldSubscribeLogGroup(cloudWatchLogs: CloudWatchLogs, logGroupName: string) {
   const subscriptionFilters = await describeSubscriptionFilters(cloudWatchLogs, logGroupName);
-  let foundDatadogSubscriptionFilter = false;
   const numberOfActiveSubscriptionFilters = subscriptionFilters.length;
-  if (numberOfActiveSubscriptionFilters === MAX_ALLOWABLE_LOG_GROUP_SUBSCRIPTIONS) {
+  if (numberOfActiveSubscriptionFilters >= MAX_ALLOWABLE_LOG_GROUP_SUBSCRIPTIONS) {
     return false;
   }
   for (const subscription of subscriptionFilters) {

--- a/serverless/src/forwarder.ts
+++ b/serverless/src/forwarder.ts
@@ -216,7 +216,7 @@ export async function shouldSubscribeLogGroup(cloudWatchLogs: CloudWatchLogs, lo
   for (const subscription of subscriptionFilters) {
     const filterName = subscription.filterName;
     if (filterName === SUBSCRIPTION_FILTER_NAME) {
-      //We found a existing datadog-cloudformation-macro subscription
+      //We found an existing datadog-cloudformation-macro subscription
       return false;
     }
   }

--- a/serverless/src/forwarder.ts
+++ b/serverless/src/forwarder.ts
@@ -57,8 +57,8 @@ export class MissingSubDeclarationError extends Error {
  *
  * We first check if a log group exists for a given lambda. If it does, we then check if there
  * are existing subscriptions. If we do not find an existing datadog-cloudformation-macro subscription and
- * the number of existing subscription filters is less than the MAX_ALLOWABLE_LOG_GROUP_SUBSCRIPTIONS then 
- * we will go ahead and add the subscription to the forwarder ARN (using AWS SDK). Otherwise we do not add 
+ * the number of existing subscription filters is less than the MAX_ALLOWABLE_LOG_GROUP_SUBSCRIPTIONS then
+ * we will go ahead and add the subscription to the forwarder ARN (using AWS SDK). Otherwise we do not add
  * the subscription.
  *
  * If no log group exists and none are declared in the customer template, we will create one
@@ -211,7 +211,7 @@ export async function shouldSubscribeLogGroup(cloudWatchLogs: CloudWatchLogs, lo
   const subscriptionFilters = await describeSubscriptionFilters(cloudWatchLogs, logGroupName);
   let foundDatadogSubscriptionFilter = false;
   const numberOfActiveSubscriptionFilters = subscriptionFilters.length;
-  if (numberOfActiveSubscriptionFilters === MAX_ALLOWABLE_LOG_GROUP_SUBSCRIPTIONS){
+  if (numberOfActiveSubscriptionFilters === MAX_ALLOWABLE_LOG_GROUP_SUBSCRIPTIONS) {
     return false;
   }
   for (const subscription of subscriptionFilters) {

--- a/serverless/test/forwarder.spec.ts
+++ b/serverless/test/forwarder.spec.ts
@@ -137,8 +137,9 @@ describe("addCloudWatchForwarderSubscriptions", () => {
     });
     expect(resources).toEqual(mockResources([lambda])); // template should not be modified
   });
+  
   //At the moment this test assumes a log group subscriptions is full when it has 2 existing subscriptions.
-  it("does not overwrite existing subscriptions on a log group whose subscriptions slots are full", async () => {
+  it("does not overwrite existing subscriptions on a log group that already has the maximum number of subscriptions", async () => {
     const lambda = mockLambdaFunction("FunctionKey", "FunctionName");
     const resources = mockResources([lambda]);
     const logGroupName = "/aws/lambda/FunctionName";
@@ -360,7 +361,8 @@ describe("shouldSubscribeLogGroup", () => {
     const shouldSub = await shouldSubscribeLogGroup(cloudWatchLogs as any, logGroupName);
     expect(shouldSub).toBe(true);
   });
-  it("returns false if the log group only has 1 existing datadog-serverless-macro-filter subscription filter.", async () => {
+
+  it("returns false if the log group only has 1 existing datadog-serverless-macro-filter subscription filter", async () => {
     const functionNamePrefix = "stack-name-FunctionKey";
     const logGroupName = `/aws/lambda/${functionNamePrefix}`;
     const cloudWatchLogs = mockCloudWatchLogs({
@@ -380,7 +382,8 @@ describe("shouldSubscribeLogGroup", () => {
     const shouldSub = await shouldSubscribeLogGroup(cloudWatchLogs as any, logGroupName);
     expect(shouldSub).toBe(false);
   });
-  it("returns true if the log group only has 1 existing non-Datadog subscription filter.", async () => {
+
+  it("returns true if the log group only has 1 existing non-Datadog subscription filter", async () => {
     const functionNamePrefix = "stack-name-FunctionKey";
     const logGroupName = `/aws/lambda/${functionNamePrefix}`;
     const cloudWatchLogs = mockCloudWatchLogs({
@@ -400,7 +403,8 @@ describe("shouldSubscribeLogGroup", () => {
     const shouldSub = await shouldSubscribeLogGroup(cloudWatchLogs as any, logGroupName);
     expect(shouldSub).toBe(true);
   });
-  it("returns false if the log group has 2 existing subscription filters, 1 datadog-cloudformation-macro filter, and 1 non-Datadog filter.", async () => {
+
+  it("returns false if the log group has 2 existing subscription filters, 1 datadog-cloudformation-macro filter, and 1 non-Datadog filter", async () => {
     const functionNamePrefix = "stack-name-FunctionKey";
     const logGroupName = `/aws/lambda/${functionNamePrefix}`;
     const cloudWatchLogs = mockCloudWatchLogs({
@@ -425,6 +429,7 @@ describe("shouldSubscribeLogGroup", () => {
     const shouldSub = await shouldSubscribeLogGroup(cloudWatchLogs as any, logGroupName);
     expect(shouldSub).toBe(false);
   });
+
   //This test assumes the maximum allowed subscriptions by a AWS Cloudwatch log group is 2.
   it("returns false if the log group has 2 existing non-datadog subscription filters", async () => {
     const functionNamePrefix = "stack-name-FunctionKey";
@@ -449,7 +454,7 @@ describe("shouldSubscribeLogGroup", () => {
       },
     });
     const shouldSub = await shouldSubscribeLogGroup(cloudWatchLogs as any, logGroupName);
-    expect(shouldSub).toBeFalsy();
+    expect(shouldSub).toBe(false);
   });
 });
 

--- a/serverless/test/forwarder.spec.ts
+++ b/serverless/test/forwarder.spec.ts
@@ -137,7 +137,7 @@ describe("addCloudWatchForwarderSubscriptions", () => {
     });
     expect(resources).toEqual(mockResources([lambda])); // template should not be modified
   });
-  
+
   //At the moment this test assumes a log group subscriptions is full when it has 2 existing subscriptions.
   it("does not overwrite existing subscriptions on a log group that already has the maximum number of subscriptions", async () => {
     const lambda = mockLambdaFunction("FunctionKey", "FunctionName");

--- a/serverless/test/forwarder.spec.ts
+++ b/serverless/test/forwarder.spec.ts
@@ -137,8 +137,8 @@ describe("addCloudWatchForwarderSubscriptions", () => {
     });
     expect(resources).toEqual(mockResources([lambda])); // template should not be modified
   });
-
-  it("does not overwrite existing unknown subscription on log group", async () => {
+  //At the moment this test assumes a log group subscriptions is full when it has 2 existing subscriptions.
+  it("does not overwrite existing subscriptions on a log group whose subscriptions slots are full", async () => {
     const lambda = mockLambdaFunction("FunctionKey", "FunctionName");
     const resources = mockResources([lambda]);
     const logGroupName = "/aws/lambda/FunctionName";
@@ -150,6 +150,11 @@ describe("addCloudWatchForwarderSubscriptions", () => {
             {
               destinationArn: "other-forwarder-arn",
               filterName: "other-filter",
+              logGroupName,
+            },
+            {
+              destinationArn: "other-forwarder-arn2",
+              filterName: "other-filter2",
               logGroupName,
             },
           ],
@@ -353,10 +358,75 @@ describe("shouldSubscribeLogGroup", () => {
       [logGroupName]: { logGroup: { logGroupName } },
     });
     const shouldSub = await shouldSubscribeLogGroup(cloudWatchLogs as any, logGroupName);
-    expect(shouldSub).toBeTruthy();
+    expect(shouldSub).toBe(true);
   });
-
-  it("returns false if there is an existing subscription", async () => {
+  it("returns false if the log group only has 1 existing datadog-serverless-macro-filter subscription filter.", async () => {
+    const functionNamePrefix = "stack-name-FunctionKey";
+    const logGroupName = `/aws/lambda/${functionNamePrefix}`;
+    const cloudWatchLogs = mockCloudWatchLogs({
+      [logGroupName]: {
+        logGroup: { logGroupName },
+        filters: {
+          subscriptionFilters: [
+            {
+              destinationArn: "destination-arn",
+              filterName: "datadog-serverless-macro-filter",
+              logGroupName,
+            },
+          ],
+        },
+      },
+    });
+    const shouldSub = await shouldSubscribeLogGroup(cloudWatchLogs as any, logGroupName);
+    expect(shouldSub).toBe(false);
+  });
+  it("returns true if the log group only has 1 existing non-Datadog subscription filter.", async () => {
+    const functionNamePrefix = "stack-name-FunctionKey";
+    const logGroupName = `/aws/lambda/${functionNamePrefix}`;
+    const cloudWatchLogs = mockCloudWatchLogs({
+      [logGroupName]: {
+        logGroup: { logGroupName },
+        filters: {
+          subscriptionFilters: [
+            {
+              destinationArn: "destination-arn",
+              filterName: "non-Datadog-filter",
+              logGroupName,
+            },
+          ],
+        },
+      },
+    });
+    const shouldSub = await shouldSubscribeLogGroup(cloudWatchLogs as any, logGroupName);
+    expect(shouldSub).toBe(true);
+  });
+  it("returns false if the log group has 2 existing subscription filters, 1 datadog-cloudformation-macro filter, and 1 non-Datadog filter.", async () => {
+    const functionNamePrefix = "stack-name-FunctionKey";
+    const logGroupName = `/aws/lambda/${functionNamePrefix}`;
+    const cloudWatchLogs = mockCloudWatchLogs({
+      [logGroupName]: {
+        logGroup: { logGroupName },
+        filters: {
+          subscriptionFilters: [
+            {
+              destinationArn: "destination-arn",
+              filterName: "non-Datadog-filter",
+              logGroupName,
+            },
+            {
+              destinationArn: "forwarder-arn",
+              filterName: "datadog-serverless-macro-filter",
+              logGroupName,
+            },
+          ],
+        },
+      },
+    });
+    const shouldSub = await shouldSubscribeLogGroup(cloudWatchLogs as any, logGroupName);
+    expect(shouldSub).toBe(false);
+  });
+  //This test assumes the maximum allowed subscriptions by a AWS Cloudwatch log group is 2.
+  it("returns false if the log group has 2 existing non-datadog subscription filters", async () => {
     const functionNamePrefix = "stack-name-FunctionKey";
     const logGroupName = `/aws/lambda/${functionNamePrefix}`;
     const cloudWatchLogs = mockCloudWatchLogs({
@@ -367,6 +437,11 @@ describe("shouldSubscribeLogGroup", () => {
             {
               destinationArn: "destination-arn",
               filterName: "another-filter",
+              logGroupName,
+            },
+            {
+              destinationArn: "other-forwarder-arn2",
+              filterName: "other-filter2",
               logGroupName,
             },
           ],


### PR DESCRIPTION
### CloudFormation Macro support for two Cloudwatch log group subscription filters


### What does this PR do?
This PR edits the logic in the forwarder.ts file to support two Cloudwatch log group subscription filters. Additionally this PR tests the new logic with unit tests in the forwarder.spec.ts file. This PR allows the Datadog Cloudformation macro to take full advantage of AWS cloudwatch log group's support for 2 log group subscription filters.
<!--- A brief description of the change being made with this pull request. --->

### Motivation
AWS Cloudwatch log groups added support for up to 2 subscription filters per log group and the Datadog Cloudformation macro logic currently only supports 1 subscription filter per log group.
<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
I added unit tests for the new cases introduced by Cloudformations support of up to 2 log group subscription filters per log group and additionally manually tested these cases by repeatedly deploying a test SAM Lambda function with the test scenarios and confirming the expected result in the AWS console.
<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
