### PR TITLE
Add runtime to layer mapping for node 14

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,4 @@ This repository contains Datadog CloudFormation macros to use with raw CloudForm
 
 * [Datadog Serverless Macro](https://github.com/DataDog/datadog-cloudformation-macro/tree/master/serverless): installs Datadog Lambda Library to Python and Node.js Lambda functions to collect custom metrics and traces
 
+

--- a/serverless/src/layer.ts
+++ b/serverless/src/layer.ts
@@ -20,9 +20,10 @@ export interface LambdaFunction {
 }
 
 const runtimeLookup: { [key: string]: RuntimeType } = {
+  "nodejs8.10": RuntimeType.NODE,
   "nodejs10.x": RuntimeType.NODE,
   "nodejs12.x": RuntimeType.NODE,
-  "nodejs8.10": RuntimeType.NODE,
+  "nodejs14.x": RuntimeType.NODE,
   "python2.7": RuntimeType.PYTHON,
   "python3.6": RuntimeType.PYTHON,
   "python3.7": RuntimeType.PYTHON,
@@ -33,6 +34,7 @@ const runtimeToLayerName: { [key: string]: string } = {
   "nodejs8.10": "Datadog-Node8-10",
   "nodejs10.x": "Datadog-Node10-x",
   "nodejs12.x": "Datadog-Node12-x",
+  "nodejs14.x": "Datadog-Node14-x",
   "python2.7": "Datadog-Python27",
   "python3.6": "Datadog-Python36",
   "python3.7": "Datadog-Python37",

--- a/serverless/test/layer.spec.ts
+++ b/serverless/test/layer.spec.ts
@@ -38,11 +38,12 @@ describe("findLambdas", () => {
       FunctionA: mockFunctionResource("nodejs8.10"),
       FunctionB: mockFunctionResource("nodejs10.x"),
       FunctionC: mockFunctionResource("nodejs12.x"),
-      FunctionD: mockFunctionResource("python2.7"),
-      FunctionE: mockFunctionResource("python3.6"),
-      FunctionF: mockFunctionResource("python3.7"),
-      FunctionG: mockFunctionResource("python3.8"),
-      FunctionH: mockFunctionResource("go1.10"),
+      FunctionD: mockFunctionResource("nodejs14.x"),
+      FunctionE: mockFunctionResource("python2.7"),
+      FunctionF: mockFunctionResource("python3.6"),
+      FunctionG: mockFunctionResource("python3.7"),
+      FunctionH: mockFunctionResource("python3.8"),
+      FunctionI: mockFunctionResource("go1.10"),
     };
     const lambdas = findLambdas(resources);
 
@@ -50,11 +51,12 @@ describe("findLambdas", () => {
       mockLambdaFunction("FunctionA", "nodejs8.10", RuntimeType.NODE),
       mockLambdaFunction("FunctionB", "nodejs10.x", RuntimeType.NODE),
       mockLambdaFunction("FunctionC", "nodejs12.x", RuntimeType.NODE),
-      mockLambdaFunction("FunctionD", "python2.7", RuntimeType.PYTHON),
-      mockLambdaFunction("FunctionE", "python3.6", RuntimeType.PYTHON),
-      mockLambdaFunction("FunctionF", "python3.7", RuntimeType.PYTHON),
-      mockLambdaFunction("FunctionG", "python3.8", RuntimeType.PYTHON),
-      mockLambdaFunction("FunctionH", "go1.10", RuntimeType.UNSUPPORTED),
+      mockLambdaFunction("FunctionD", "nodejs14.x", RuntimeType.NODE),
+      mockLambdaFunction("FunctionE", "python2.7", RuntimeType.PYTHON),
+      mockLambdaFunction("FunctionF", "python3.6", RuntimeType.PYTHON),
+      mockLambdaFunction("FunctionG", "python3.7", RuntimeType.PYTHON),
+      mockLambdaFunction("FunctionH", "python3.8", RuntimeType.PYTHON),
+      mockLambdaFunction("FunctionI", "go1.10", RuntimeType.UNSUPPORTED),
     ]);
   });
 });


### PR DESCRIPTION
### What does this PR do?

Add runtime to layer mapping for node 14

### Motivation

Allow using dd-trace in the new node 14 runtime without error: `Cannot find module 'dd-trace'`

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
