### PR TITLE
Support for Datadog Lambda Extension

### DIFF
--- a/serverless/src/env.ts
+++ b/serverless/src/env.ts
@@ -106,9 +106,9 @@ export function getConfigFromCfnParams(params: CfnParams) {
 export function validateParameters(config: Configuration) {
   log.debug("Validating parameters...");
   const errors: string[] = [];
-  const siteList: string[] = ["datadoghq.com", "datadoghq.eu"];
+  const siteList: string[] = ["datadoghq.com", "datadoghq.eu", "us3.datadoghq.com", "ddog-gov.com"];
   if (config.site !== undefined && !siteList.includes(config.site.toLowerCase())) {
-    errors.push("Warning: Invalid site URL. Must be either datadoghq.com or datadoghq.eu.");
+    errors.push("Warning: Invalid site URL. Must be either datadoghq.com, datadoghq.eu, us3.datadoghq.com, or ddog-gov.com.");
   }
   if (config.extensionLayerVersion !== undefined) {
     if (config.forwarderArn !== undefined) {

--- a/serverless/src/env.ts
+++ b/serverless/src/env.ts
@@ -108,7 +108,9 @@ export function validateParameters(config: Configuration) {
   const errors: string[] = [];
   const siteList: string[] = ["datadoghq.com", "datadoghq.eu", "us3.datadoghq.com", "ddog-gov.com"];
   if (config.site !== undefined && !siteList.includes(config.site.toLowerCase())) {
-    errors.push("Warning: Invalid site URL. Must be either datadoghq.com, datadoghq.eu, us3.datadoghq.com, or ddog-gov.com.");
+    errors.push(
+      "Warning: Invalid site URL. Must be either datadoghq.com, datadoghq.eu, us3.datadoghq.com, or ddog-gov.com.",
+    );
   }
   if (config.extensionLayerVersion !== undefined) {
     if (config.forwarderArn !== undefined) {

--- a/serverless/src/env.ts
+++ b/serverless/src/env.ts
@@ -115,7 +115,7 @@ export function validateParameters(config: Configuration) {
       errors.push("`extensionLayerVersion` and `forwarderArn` cannot be set at the same time.");
     }
     if (config.apiKey === undefined && config.apiKMSKey === undefined) {
-      errors.push("When `extensionLayer` is set, `apiKey` or `apiKmsKey` must also be set.");
+      errors.push("When `extensionLayerVersion` is set, `apiKey` or `apiKmsKey` must also be set.");
     }
   }
   return errors;

--- a/serverless/src/env.ts
+++ b/serverless/src/env.ts
@@ -9,7 +9,7 @@ export interface Configuration {
   // Node.js Lambda layer version
   nodeLayerVersion?: number;
   // Datadog Lambda Extension layer version
-  extensionLayerVersion?:number;
+  extensionLayerVersion?: number;
   // Datadog API Key, only necessary when using metrics without log forwarding
   apiKey?: string;
   // Datadog API Key encrypted using KMS, only necessary when using metrics without log forwarding

--- a/serverless/src/index.ts
+++ b/serverless/src/index.ts
@@ -85,7 +85,13 @@ export const handler = async (event: InputEvent, _: any) => {
     // Apply layers
     if (config.addLayers) {
       log.debug("Applying Layers to Lambda functions...");
-      errors = applyLayers(region, lambdas, config.pythonLayerVersion, config.nodeLayerVersion, config.extensionLayerVersion);
+      errors = applyLayers(
+        region,
+        lambdas,
+        config.pythonLayerVersion,
+        config.nodeLayerVersion,
+        config.extensionLayerVersion,
+      );
       if (errors.length > 0) {
         return {
           requestId: event.requestId,

--- a/serverless/src/index.ts
+++ b/serverless/src/index.ts
@@ -1,4 +1,4 @@
-import { getConfigFromCfnMappings, getConfigFromCfnParams, setEnvConfiguration } from "./env";
+import { getConfigFromCfnMappings, getConfigFromCfnParams, setEnvConfiguration, validateParameters } from "./env";
 import { findLambdas, applyLayers, LambdaFunction } from "./layer";
 import { getTracingMode, enableTracing, MissingIamRoleError, TracingMode } from "./tracing";
 import { addServiceAndEnvTags, addMacroTag, addCDKTag, addSAMTag } from "./tags";
@@ -55,7 +55,7 @@ export const handler = async (event: InputEvent, _: any) => {
     const resources = fragment.Resources;
 
     let config;
-
+    let errors;
     // Use the parameters given for this specific transform/macro if it exists
     const transformParams = event.params ?? {};
     if (Object.keys(transformParams).length > 0) {
@@ -65,6 +65,15 @@ export const handler = async (event: InputEvent, _: any) => {
       // If not, check the Mappings section for Datadog config parameters as well
       log.debug("Parsing config from CloudFormation template mappings");
       config = getConfigFromCfnMappings(fragment.Mappings);
+    }
+    errors = validateParameters(config);
+    if (errors.length > 0) {
+      return {
+        requestId: event.requestId,
+        status: FAILURE,
+        fragment,
+        errorMessage: errors.join("\n"),
+      };
     }
 
     const lambdas = findLambdas(resources);
@@ -76,7 +85,7 @@ export const handler = async (event: InputEvent, _: any) => {
     // Apply layers
     if (config.addLayers) {
       log.debug("Applying Layers to Lambda functions...");
-      const errors = applyLayers(region, lambdas, config.pythonLayerVersion, config.nodeLayerVersion);
+      errors = applyLayers(region, lambdas, config.pythonLayerVersion, config.nodeLayerVersion, config.extensionLayerVersion);
       if (errors.length > 0) {
         return {
           requestId: event.requestId,

--- a/serverless/src/layer.ts
+++ b/serverless/src/layer.ts
@@ -4,7 +4,7 @@ import log from "loglevel";
 const LAMBDA_FUNCTION_RESOURCE_TYPE = "AWS::Lambda::Function";
 export const DD_ACCOUNT_ID = "464622532012";
 export const DD_GOV_ACCOUNT_ID = "002406178527";
-const DD_LAMBDA_EXTENSION_LAYER_NAME= "Datadog-Extension";
+const DD_LAMBDA_EXTENSION_LAYER_NAME = "Datadog-Extension";
 
 export enum RuntimeType {
   NODE,
@@ -169,10 +169,9 @@ function addLayer(layerArn: string, lambda: LambdaFunction) {
 
 export function getLayerARN(region: string, version: number, runtime: string, addExtension?: boolean) {
   let layerName;
-  if (addExtension===true){
+  if (addExtension === true) {
     layerName = DD_LAMBDA_EXTENSION_LAYER_NAME;
-  }
-  else {
+  } else {
     layerName = runtimeToLayerName[runtime];
   }
   const isGovCloud = region === "us-gov-east-1" || region === "us-gov-west-1";

--- a/serverless/src/layer.ts
+++ b/serverless/src/layer.ts
@@ -40,7 +40,7 @@ const runtimeToLayerName: { [key: string]: string } = {
   "python3.6": "Datadog-Python36",
   "python3.7": "Datadog-Python37",
   "python3.8": "Datadog-Python38",
-  "LambdaExtension":"Datadog-Extension",
+  LambdaExtension: "Datadog-Extension",
 };
 
 const availableRegions = new Set([
@@ -149,7 +149,7 @@ export function applyLayers(
     }
 
     if (extensionLayerVersion !== undefined) {
-      log.debug(`Setting Lambda Extension layer for ${lambda.key}`)
+      log.debug(`Setting Lambda Extension layer for ${lambda.key}`);
       lambdaExtensionLayerArn = getLayerARN(region, extensionLayerVersion, "LambdaExtension");
       addLayer(lambdaExtensionLayerArn, lambda);
     }
@@ -157,7 +157,7 @@ export function applyLayers(
   return errors;
 }
 
-function addLayer(layerArn: string, lambda: LambdaFunction){
+function addLayer(layerArn: string, lambda: LambdaFunction) {
   if (layerArn !== undefined) {
     const currentLayers = lambda.properties.Layers ?? [];
     if (!new Set(currentLayers).has(layerArn)) {

--- a/serverless/test/env.spec.ts
+++ b/serverless/test/env.spec.ts
@@ -165,6 +165,8 @@ describe("validateParameters", () => {
     };
 
     const errors = validateParameters(params);
-    expect(errors.includes("When `extensionLayer` is set, `apiKey` or `apiKmsKey` must also be set.")).toBe(true);
+    expect(errors.includes("When `extensionLayerVersion` is set, `apiKey` or `apiKmsKey` must also be set.")).toBe(
+      true,
+    );
   });
 });

--- a/serverless/test/env.spec.ts
+++ b/serverless/test/env.spec.ts
@@ -130,9 +130,9 @@ describe("validateParameters", () => {
       enableDDTracing: true,
       enableEnhancedMetrics: true,
     };
-    
-    let errors = validateParameters(params);
-    expect(errors.includes('Warning: Invalid site URL. Must be either datadoghq.com or datadoghq.eu.')).toBe(true);
+
+    const errors = validateParameters(params);
+    expect(errors.includes("Warning: Invalid site URL. Must be either datadoghq.com or datadoghq.eu.")).toBe(true);
   });
 
   it("returns an error when extensionLayerVersion and forwarderArn are set", () => {
@@ -147,9 +147,9 @@ describe("validateParameters", () => {
       extensionLayerVersion: 6,
       forwarderArn: "test-forwarder",
     };
-    
-    let errors = validateParameters(params);
-    expect(errors.includes('`extensionLayerVersion` and `forwarderArn` cannot be set at the same time.')).toBe(true);
+
+    const errors = validateParameters(params);
+    expect(errors.includes("`extensionLayerVersion` and `forwarderArn` cannot be set at the same time.")).toBe(true);
   });
 
   it("returns an error when extensionLayerVersion is set but neither apiKey nor apiKMSKey is set", () => {
@@ -163,8 +163,8 @@ describe("validateParameters", () => {
       enableEnhancedMetrics: true,
       extensionLayerVersion: 6,
     };
-    
-    let errors = validateParameters(params);
-    expect(errors.includes('When `extensionLayer` is set, `apiKey` or `apiKmsKey` must also be set.')).toBe(true);
+
+    const errors = validateParameters(params);
+    expect(errors.includes("When `extensionLayer` is set, `apiKey` or `apiKmsKey` must also be set.")).toBe(true);
   });
 });

--- a/serverless/test/env.spec.ts
+++ b/serverless/test/env.spec.ts
@@ -132,7 +132,7 @@ describe("validateParameters", () => {
     };
 
     const errors = validateParameters(params);
-    expect(errors.includes("Warning: Invalid site URL. Must be either datadoghq.com or datadoghq.eu.")).toBe(true);
+    expect(errors.includes("Warning: Invalid site URL. Must be either datadoghq.com, datadoghq.eu, us3.datadoghq.com, or ddog-gov.com.")).toBe(true);
   });
 
   it("returns an error when extensionLayerVersion and forwarderArn are set", () => {

--- a/serverless/test/env.spec.ts
+++ b/serverless/test/env.spec.ts
@@ -132,7 +132,11 @@ describe("validateParameters", () => {
     };
 
     const errors = validateParameters(params);
-    expect(errors.includes("Warning: Invalid site URL. Must be either datadoghq.com, datadoghq.eu, us3.datadoghq.com, or ddog-gov.com.")).toBe(true);
+    expect(
+      errors.includes(
+        "Warning: Invalid site URL. Must be either datadoghq.com, datadoghq.eu, us3.datadoghq.com, or ddog-gov.com.",
+      ),
+    ).toBe(true);
   });
 
   it("returns an error when extensionLayerVersion and forwarderArn are set", () => {

--- a/serverless/test/index.spec.ts
+++ b/serverless/test/index.spec.ts
@@ -134,7 +134,7 @@ function mockGovCloudInputEvent(params: any, mappings: any, logGroups?: LogGroup
 describe("Macro", () => {
   describe("parameters and config", () => {
     it("uses transform parameters if they are provided", async () => {
-      const transformParams = { site: "transform-params-site" };
+      const transformParams = { site: "datadoghq.com" };
       const mappings = {
         Datadog: {
           Parameters: { site: "mappings-site" },
@@ -145,14 +145,14 @@ describe("Macro", () => {
       const lambdaProperties: FunctionProperties = output.fragment.Resources[LAMBDA_KEY].Properties;
 
       expect(lambdaProperties.Environment).toMatchObject({
-        Variables: { DD_SITE: "transform-params-site" },
+        Variables: { DD_SITE: "datadoghq.com" },
       });
     });
 
     it("uses parameters under Mappings section if template parameters are not given", async () => {
       const mappings = {
         Datadog: {
-          Parameters: { site: "mappings-site" },
+          Parameters: { site: "datadoghq.eu" },
         },
       };
       const inputEvent = mockInputEvent({}, mappings);
@@ -160,7 +160,7 @@ describe("Macro", () => {
       const lambdaProperties: FunctionProperties = output.fragment.Resources[LAMBDA_KEY].Properties;
 
       expect(lambdaProperties.Environment).toMatchObject({
-        Variables: { DD_SITE: "mappings-site" },
+        Variables: { DD_SITE: "datadoghq.eu" },
       });
     });
   });

--- a/serverless/test/layer.spec.ts
+++ b/serverless/test/layer.spec.ts
@@ -199,6 +199,13 @@ describe("getLambdaLibraryLayerArn", () => {
     const layerArn = getLambdaLibraryLayerArn(region, version, runtime);
     expect(layerArn).toEqual(`arn:aws-us-gov:lambda:${region}:${DD_GOV_ACCOUNT_ID}:layer:Datadog-Python36:${version}`);
   });
+  it("gets the us-gov-east-1 layer arn for the Datadog Node14 Lambda Library", () => {
+    const region = "us-gov-east-1";
+    const version = 22;
+    const runtime = "nodejs14.x";
+    const layerArn = getLambdaLibraryLayerArn(region, version, runtime);
+    expect(layerArn).toEqual(`arn:aws-us-gov:lambda:${region}:${DD_GOV_ACCOUNT_ID}:layer:Datadog-Node14-x:${version}`);
+  });
 });
 
 describe("getExtensionLayerArn", () => {

--- a/serverless/test/layer.spec.ts
+++ b/serverless/test/layer.spec.ts
@@ -180,8 +180,7 @@ describe("getLayerARN", () => {
   it("gets the layer arn for the Datadog Lambda Extension", () => {
     const region = "us-east-1";
     const version = 22;
-    const runtime = "LambdaExtension";
-    const layerArn = getLayerARN(region, version, runtime);
+    const layerArn = getLayerARN(region, version, "test", true);
     expect(layerArn).toEqual(`arn:aws:lambda:${region}:${DD_ACCOUNT_ID}:layer:Datadog-Extension:${version}`);
   });
   it("gets the layer arn for the Datadog Node Lambda Library", () => {

--- a/serverless/test/layer.spec.ts
+++ b/serverless/test/layer.spec.ts
@@ -6,7 +6,8 @@ import {
   DD_ACCOUNT_ID,
   DD_GOV_ACCOUNT_ID,
   getMissingLayerVersionErrorMsg,
-  getLayerARN,
+  getLambdaLibraryLayerArn,
+  getExtensionLayerArn,
 } from "../src/layer";
 
 function mockFunctionResource(runtime: string) {
@@ -176,25 +177,41 @@ describe("isGovCloud", () => {
   });
 });
 
-describe("getLayerARN", () => {
-  it("gets the layer arn for the Datadog Lambda Extension", () => {
-    const region = "us-east-1";
-    const version = 22;
-    const layerArn = getLayerARN(region, version, "test", true);
-    expect(layerArn).toEqual(`arn:aws:lambda:${region}:${DD_ACCOUNT_ID}:layer:Datadog-Extension:${version}`);
-  });
-  it("gets the layer arn for the Datadog Node Lambda Library", () => {
+describe("getLambdaLibraryLayerArn", () => {
+  it("gets the us-east-1 layer arn for the Datadog Node14 Lambda Library", () => {
     const region = "us-east-1";
     const version = 22;
     const runtime = "nodejs14.x";
-    const layerArn = getLayerARN(region, version, runtime);
+    const layerArn = getLambdaLibraryLayerArn(region, version, runtime);
     expect(layerArn).toEqual(`arn:aws:lambda:${region}:${DD_ACCOUNT_ID}:layer:Datadog-Node14-x:${version}`);
   });
-  it("gets the layer arn for the Datadog Python Lambda Library", () => {
+  it("gets the us-east-1 layer arn for the Datadog Python36 Lambda Library", () => {
     const region = "us-east-1";
     const version = 22;
     const runtime = "python3.6";
-    const layerArn = getLayerARN(region, version, runtime);
+    const layerArn = getLambdaLibraryLayerArn(region, version, runtime);
     expect(layerArn).toEqual(`arn:aws:lambda:${region}:${DD_ACCOUNT_ID}:layer:Datadog-Python36:${version}`);
+  });
+  it("gets the us-gov-east-1 layer arn for the Datadog Python36 Lambda Library", () => {
+    const region = "us-gov-east-1";
+    const version = 22;
+    const runtime = "python3.6";
+    const layerArn = getLambdaLibraryLayerArn(region, version, runtime);
+    expect(layerArn).toEqual(`arn:aws-us-gov:lambda:${region}:${DD_GOV_ACCOUNT_ID}:layer:Datadog-Python36:${version}`);
+  });
+});
+
+describe("getExtensionLayerArn", () => {
+  it("gets the us-east-1 layer arn for the Datadog Lambda Extension", () => {
+    const region = "us-east-1";
+    const version = 6;
+    const layerArn = getExtensionLayerArn(region, version);
+    expect(layerArn).toEqual(`arn:aws:lambda:${region}:${DD_ACCOUNT_ID}:layer:Datadog-Extension:${version}`);
+  });
+  it("gets the us-gov-west-1 layer arn for the Datadog Lambda Extension", () => {
+    const region = "us-gov-west-1";
+    const version = 6;
+    const layerArn = getExtensionLayerArn(region, version);
+    expect(layerArn).toEqual(`arn:aws-us-gov:lambda:${region}:${DD_GOV_ACCOUNT_ID}:layer:Datadog-Extension:${version}`);
   });
 });

--- a/serverless/test/layer.spec.ts
+++ b/serverless/test/layer.spec.ts
@@ -181,21 +181,21 @@ describe("getLayerARN", () => {
     const region = "us-east-1";
     const version = 22;
     const runtime = "LambdaExtension";
-    const layerArn = getLayerARN(region,version,runtime);
+    const layerArn = getLayerARN(region, version, runtime);
     expect(layerArn).toEqual(`arn:aws:lambda:${region}:${DD_ACCOUNT_ID}:layer:Datadog-Extension:${version}`);
   });
   it("gets the layer arn for the Datadog Node Lambda Library", () => {
     const region = "us-east-1";
     const version = 22;
     const runtime = "nodejs14.x";
-    const layerArn = getLayerARN(region,version,runtime);
+    const layerArn = getLayerARN(region, version, runtime);
     expect(layerArn).toEqual(`arn:aws:lambda:${region}:${DD_ACCOUNT_ID}:layer:Datadog-Node14-x:${version}`);
   });
   it("gets the layer arn for the Datadog Python Lambda Library", () => {
     const region = "us-east-1";
     const version = 22;
     const runtime = "python3.6";
-    const layerArn = getLayerARN(region,version,runtime);
+    const layerArn = getLayerARN(region, version, runtime);
     expect(layerArn).toEqual(`arn:aws:lambda:${region}:${DD_ACCOUNT_ID}:layer:Datadog-Python36:${version}`);
   });
 });

--- a/serverless/test/layer.spec.ts
+++ b/serverless/test/layer.spec.ts
@@ -6,6 +6,7 @@ import {
   DD_ACCOUNT_ID,
   DD_GOV_ACCOUNT_ID,
   getMissingLayerVersionErrorMsg,
+  getLayerARN,
 } from "../src/layer";
 
 function mockFunctionResource(runtime: string) {
@@ -129,6 +130,34 @@ describe("applyLayers", () => {
     expect(pythonLambda.properties.Layers).toBeUndefined();
     expect(nodeLambda.properties.Layers).toBeUndefined();
   });
+
+  it("applies the node and extension lambda layers", () => {
+    const lambda = mockLambdaFunction("FunctionKey", "nodejs12.x", RuntimeType.NODE);
+    const region = "us-east-1";
+    const nodeLayerVersion = 25;
+    const extensionLayerVersion = 6;
+    const errors = applyLayers(region, [lambda], undefined, nodeLayerVersion, extensionLayerVersion);
+
+    expect(errors.length).toEqual(0);
+    expect(lambda.properties.Layers).toEqual([
+      `arn:aws:lambda:${region}:${DD_ACCOUNT_ID}:layer:Datadog-Node12-x:${nodeLayerVersion}`,
+      `arn:aws:lambda:${region}:${DD_ACCOUNT_ID}:layer:Datadog-Extension:${extensionLayerVersion}`,
+    ]);
+  });
+
+  it("applies the python and extension lambda layers", () => {
+    const lambda = mockLambdaFunction("FunctionKey", "python3.6", RuntimeType.PYTHON);
+    const region = "us-east-1";
+    const pythonLayerVersion = 25;
+    const extensionLayerVersion = 6;
+    const errors = applyLayers(region, [lambda], pythonLayerVersion, undefined, extensionLayerVersion);
+
+    expect(errors.length).toEqual(0);
+    expect(lambda.properties.Layers).toEqual([
+      `arn:aws:lambda:${region}:${DD_ACCOUNT_ID}:layer:Datadog-Python36:${pythonLayerVersion}`,
+      `arn:aws:lambda:${region}:${DD_ACCOUNT_ID}:layer:Datadog-Extension:${extensionLayerVersion}`,
+    ]);
+  });
 });
 
 describe("isGovCloud", () => {
@@ -144,5 +173,29 @@ describe("isGovCloud", () => {
     expect(nodeLambda.properties.Layers).toEqual([
       `arn:aws-us-gov:lambda:us-gov-east-1:${DD_GOV_ACCOUNT_ID}:layer:Datadog-Node10-x:30`,
     ]);
+  });
+});
+
+describe("getLayerARN", () => {
+  it("gets the layer arn for the Datadog Lambda Extension", () => {
+    const region = "us-east-1";
+    const version = 22;
+    const runtime = "LambdaExtension";
+    const layerArn = getLayerARN(region,version,runtime);
+    expect(layerArn).toEqual(`arn:aws:lambda:${region}:${DD_ACCOUNT_ID}:layer:Datadog-Extension:${version}`);
+  });
+  it("gets the layer arn for the Datadog Node Lambda Library", () => {
+    const region = "us-east-1";
+    const version = 22;
+    const runtime = "nodejs14.x";
+    const layerArn = getLayerARN(region,version,runtime);
+    expect(layerArn).toEqual(`arn:aws:lambda:${region}:${DD_ACCOUNT_ID}:layer:Datadog-Node14-x:${version}`);
+  });
+  it("gets the layer arn for the Datadog Python Lambda Library", () => {
+    const region = "us-east-1";
+    const version = 22;
+    const runtime = "python3.6";
+    const layerArn = getLayerARN(region,version,runtime);
+    expect(layerArn).toEqual(`arn:aws:lambda:${region}:${DD_ACCOUNT_ID}:layer:Datadog-Python36:${version}`);
   });
 });


### PR DESCRIPTION
### What does this PR do?
This PR adds support for the Datadog Lambda Extension via the CloudFormation Macro.
<!--- A brief description of the change being made with this pull request. --->

### Motivation
The team is making progress towards releasing the Datadog Lambda Extension for GA therefore we are putting in effort now to our existing integrations to add support for the Lambda Extension.
<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
I manually deployed the CloudFormation stack to sandbox and used it in a sample SAM and CDK deployment. The Datadog Extension was added as a layer and did not break any of the existing layer adding logic.

I added a few local tests for the code changes I added.
<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
