### PR TITLE
feature: Set DD_SERVERLESS_LOGS_ENABLED via enableDDLogs config

### DIFF
--- a/serverless/README.md
+++ b/serverless/README.md
@@ -74,6 +74,7 @@ To further configure your plugin, use the following custom parameters:
 | `enableEnhancedMetrics` | Enable enhanced metrics for Lambda functions. Defaults to `true`. The Datadog Forwarder Lambda function must subscribe the function log group. |
 | `enableXrayTracing` | Enable tracing on Lambda functions. Defaults to false. |
 | `enableDDTracing` | Enable tracing on Lambda function using dd-trace, Datadog's APM library. Defaults to `true`. The Datadog Forwarder Lambda function must subscribe the function log group. |
+| `enableDDLogs` | Enable Datadog log collection for the Lambda function. Note: This setting has no effect on logs sent via the Datadog Forwarder. Defaults to true. |
 | `service` | When set, the macro adds a `service` tag to all Lambda functions with the provided value. |
 | `env` | When set, the macro adds an `env` tag to all Lambda functions with the provided value. |
 | `logLevel` | Sets the log level. Set to `DEBUG` for extended logging. |

--- a/serverless/src/env.ts
+++ b/serverless/src/env.ts
@@ -26,6 +26,8 @@ export interface Configuration {
   enableXrayTracing: boolean;
   // Enable tracing on Lambda function using dd-trace, datadog's APM library.
   enableDDTracing: boolean;
+  // Enable log collection via the Datadog Lambda extension
+  enableDDLogs: boolean;
   // When set, the macro will subscribe the lambdas to the forwarder with the given arn.
   forwarderArn?: string;
   // If a forwarder is provided and any lambdas have dynamically generated names,
@@ -51,6 +53,7 @@ const siteURLEnvVar = "DD_SITE";
 const logLevelEnvVar = "DD_LOG_LEVEL";
 const logForwardingEnvVar = "DD_FLUSH_TO_LOG";
 const enhancedMetricsEnvVar = "DD_ENHANCED_METRICS";
+const enableDDLogsEnvVar = "DD_SERVERLESS_LOGS_ENABLED";
 const DATADOG = "Datadog";
 const PARAMETERS = "Parameters";
 
@@ -61,6 +64,7 @@ export const defaultConfiguration: Configuration = {
   site: "datadoghq.com",
   enableXrayTracing: false,
   enableDDTracing: true,
+  enableDDLogs: true,
   enableEnhancedMetrics: true,
 };
 
@@ -149,6 +153,10 @@ export function setEnvConfiguration(config: Configuration, lambdas: LambdaFuncti
 
     if (envVariables[enhancedMetricsEnvVar] === undefined) {
       envVariables[enhancedMetricsEnvVar] = config.enableEnhancedMetrics;
+    }
+
+    if (config.enableDDLogs !== undefined && envVariables[enableDDLogsEnvVar] === undefined) {
+      envVariables[enableDDLogsEnvVar] = config.enableDDLogs;
     }
 
     environment.Variables = envVariables;

--- a/serverless/test/env.spec.ts
+++ b/serverless/test/env.spec.ts
@@ -35,6 +35,7 @@ describe("getConfig", () => {
       site: "my-site",
       enableXrayTracing: false,
       enableDDTracing: true,
+      enableDDLogs: true,
       enableEnhancedMetrics: true,
     });
   });
@@ -62,6 +63,7 @@ describe("setEnvConfiguration", () => {
       flushMetricsToLogs: true,
       enableXrayTracing: true,
       enableDDTracing: true,
+      enableDDLogs: true,
       enableEnhancedMetrics: true,
     };
     setEnvConfiguration(config, [lambda]);
@@ -74,6 +76,7 @@ describe("setEnvConfiguration", () => {
         DD_LOG_LEVEL: "debug",
         DD_SITE: "datadoghq.eu",
         DD_ENHANCED_METRICS: true,
+        DD_SERVERLESS_LOGS_ENABLED: true,
       },
     });
   });
@@ -108,6 +111,7 @@ describe("setEnvConfiguration", () => {
       flushMetricsToLogs: false,
       enableXrayTracing: true,
       enableDDTracing: true,
+      enableDDLogs: true,
       enableEnhancedMetrics: false,
     };
     setEnvConfiguration(config, [lambda]);
@@ -138,6 +142,7 @@ describe("setEnvConfiguration", () => {
       flushMetricsToLogs: true,
       enableXrayTracing: true,
       enableDDTracing: true,
+      enableDDLogs: true,
       enableEnhancedMetrics: true,
     };
     setEnvConfiguration(config, [lambda]);
@@ -149,6 +154,7 @@ describe("setEnvConfiguration", () => {
         DD_KMS_API_KEY: "5678",
         DD_SITE: "datadoghq.eu",
         DD_ENHANCED_METRICS: true,
+        DD_SERVERLESS_LOGS_ENABLED: true,
       },
     });
   });
@@ -174,6 +180,7 @@ describe("setEnvConfiguration", () => {
       flushMetricsToLogs: true,
       enableXrayTracing: true,
       enableDDTracing: true,
+      enableDDLogs: true,
       enableEnhancedMetrics: true,
     };
     setEnvConfiguration(config, [lambda]);
@@ -186,6 +193,7 @@ describe("setEnvConfiguration", () => {
         DD_LOG_LEVEL: "info",
         DD_SITE: "datadoghq.eu",
         DD_ENHANCED_METRICS: true,
+        DD_SERVERLESS_LOGS_ENABLED: true,
       },
     });
   });
@@ -200,6 +208,7 @@ describe("validateParameters", () => {
       site: "datacathq.com",
       enableXrayTracing: false,
       enableDDTracing: true,
+      enableDDLogs: true,
       enableEnhancedMetrics: true,
     };
 
@@ -219,6 +228,7 @@ describe("validateParameters", () => {
       site: "datadoghq.com",
       enableXrayTracing: false,
       enableDDTracing: true,
+      enableDDLogs: true,
       enableEnhancedMetrics: true,
       extensionLayerVersion: 6,
       forwarderArn: "test-forwarder",
@@ -236,6 +246,7 @@ describe("validateParameters", () => {
       site: "datadoghq.com",
       enableXrayTracing: false,
       enableDDTracing: true,
+      enableDDLogs: true,
       enableEnhancedMetrics: true,
       extensionLayerVersion: 6,
     };


### PR DESCRIPTION
### What does this PR do?

Sets DD_SERVERLESS_LOGS_ENABLED environment variable (default: `true`) via `enableDDLogs` config

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [x] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
