### PR TITLE
Add support for Python 3.9, remove region validation

### DIFF
--- a/serverless/src/layer.ts
+++ b/serverless/src/layer.ts
@@ -22,7 +22,6 @@ export interface LambdaFunction {
 }
 
 const runtimeLookup: { [key: string]: RuntimeType } = {
-  "nodejs8.10": RuntimeType.NODE,
   "nodejs10.x": RuntimeType.NODE,
   "nodejs12.x": RuntimeType.NODE,
   "nodejs14.x": RuntimeType.NODE,
@@ -30,10 +29,10 @@ const runtimeLookup: { [key: string]: RuntimeType } = {
   "python3.6": RuntimeType.PYTHON,
   "python3.7": RuntimeType.PYTHON,
   "python3.8": RuntimeType.PYTHON,
+  "python3.9": RuntimeType.PYTHON,
 };
 
 const runtimeToLayerName: { [key: string]: string } = {
-  "nodejs8.10": "Datadog-Node8-10",
   "nodejs10.x": "Datadog-Node10-x",
   "nodejs12.x": "Datadog-Node12-x",
   "nodejs14.x": "Datadog-Node14-x",
@@ -41,29 +40,8 @@ const runtimeToLayerName: { [key: string]: string } = {
   "python3.6": "Datadog-Python36",
   "python3.7": "Datadog-Python37",
   "python3.8": "Datadog-Python38",
+  "python3.9": "Datadog-Python39",
 };
-
-const availableRegions = new Set([
-  "us-east-2",
-  "us-east-1",
-  "us-west-1",
-  "us-west-2",
-  "ap-east-1",
-  "ap-south-1",
-  "ap-northeast-2",
-  "ap-southeast-1",
-  "ap-southeast-2",
-  "ap-northeast-1",
-  "ca-central-1",
-  "eu-north-1",
-  "eu-central-1",
-  "eu-west-1",
-  "eu-west-2",
-  "eu-west-3",
-  "sa-east-1",
-  "us-gov-east-1",
-  "us-gov-west-1",
-]);
 
 /**
  * Parse through the Resources section of the provided CloudFormation template to find all lambda
@@ -112,10 +90,6 @@ export function applyLayers(
   nodeLayerVersion?: number,
   extensionLayerVersion?: number,
 ) {
-  if (!availableRegions.has(region)) {
-    return [];
-  }
-
   const errors: string[] = [];
   lambdas.forEach((lambda) => {
     if (lambda.runtimeType === RuntimeType.UNSUPPORTED) {

--- a/serverless/test/layer.spec.ts
+++ b/serverless/test/layer.spec.ts
@@ -35,30 +35,30 @@ function mockLambdaFunction(key: string, runtime: string, runtimeType: RuntimeTy
 }
 
 describe("findLambdas", () => {
-  it("finds lambdas and correct assigns runtime types", () => {
+  it("finds lambdas and correctly assigns runtime types", () => {
     const resources = {
-      FunctionA: mockFunctionResource("nodejs8.10"),
-      FunctionB: mockFunctionResource("nodejs10.x"),
-      FunctionC: mockFunctionResource("nodejs12.x"),
-      FunctionD: mockFunctionResource("nodejs14.x"),
-      FunctionE: mockFunctionResource("python2.7"),
-      FunctionF: mockFunctionResource("python3.6"),
-      FunctionG: mockFunctionResource("python3.7"),
-      FunctionH: mockFunctionResource("python3.8"),
-      FunctionI: mockFunctionResource("go1.10"),
+      Node10Function: mockFunctionResource("nodejs10.x"),
+      Node12Function: mockFunctionResource("nodejs12.x"),
+      Node14Function: mockFunctionResource("nodejs14.x"),
+      Python27Function: mockFunctionResource("python2.7"),
+      Python36Function: mockFunctionResource("python3.6"),
+      Python37Function: mockFunctionResource("python3.7"),
+      Python38Function: mockFunctionResource("python3.8"),
+      Python39Function: mockFunctionResource("python3.9"),
+      GoFunction: mockFunctionResource("go1.10"),
     };
     const lambdas = findLambdas(resources);
 
     expect(lambdas).toEqual([
-      mockLambdaFunction("FunctionA", "nodejs8.10", RuntimeType.NODE),
-      mockLambdaFunction("FunctionB", "nodejs10.x", RuntimeType.NODE),
-      mockLambdaFunction("FunctionC", "nodejs12.x", RuntimeType.NODE),
-      mockLambdaFunction("FunctionD", "nodejs14.x", RuntimeType.NODE),
-      mockLambdaFunction("FunctionE", "python2.7", RuntimeType.PYTHON),
-      mockLambdaFunction("FunctionF", "python3.6", RuntimeType.PYTHON),
-      mockLambdaFunction("FunctionG", "python3.7", RuntimeType.PYTHON),
-      mockLambdaFunction("FunctionH", "python3.8", RuntimeType.PYTHON),
-      mockLambdaFunction("FunctionI", "go1.10", RuntimeType.UNSUPPORTED),
+      mockLambdaFunction("Node10Function", "nodejs10.x", RuntimeType.NODE),
+      mockLambdaFunction("Node12Function", "nodejs12.x", RuntimeType.NODE),
+      mockLambdaFunction("Node14Function", "nodejs14.x", RuntimeType.NODE),
+      mockLambdaFunction("Python27Function", "python2.7", RuntimeType.PYTHON),
+      mockLambdaFunction("Python36Function", "python3.6", RuntimeType.PYTHON),
+      mockLambdaFunction("Python37Function", "python3.7", RuntimeType.PYTHON),
+      mockLambdaFunction("Python38Function", "python3.8", RuntimeType.PYTHON),
+      mockLambdaFunction("Python39Function", "python3.9", RuntimeType.PYTHON),
+      mockLambdaFunction("GoFunction", "go1.10", RuntimeType.UNSUPPORTED),
     ]);
   });
 });
@@ -101,14 +101,6 @@ describe("applyLayers", () => {
 
     expect(errors.length).toEqual(0);
     expect(lambda.properties.Layers).toEqual([layerArn]);
-  });
-
-  it("only adds layer when region it is available in region", () => {
-    const lambda = mockLambdaFunction("FunctionKey", "nodejs12.x", RuntimeType.NODE);
-    const errors = applyLayers("unsupported-region", [lambda], 18);
-
-    expect(errors.length).toEqual(0);
-    expect(lambda.properties.Layers).toBeUndefined();
   });
 
   it("doesn't add layer when runtime is not supported", () => {


### PR DESCRIPTION
### What does this PR do?

- Add support for the Python 3.9 runtime
- Remove support for Node 8.10 runtime. This is not a breaking change because it has not been possible to update or create a Lambda function using this runtime since March 6, 2020.
- Remove region validation. The list of regions we validated against was out of date (it did not include `me-south-1`, `af-south-1`, or `eu-south-1`). It's difficult to keep this list up to date, and we don't do this type of validation in our other deployment tools.

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
