### PR TITLE
feat: add support for arm64 lamdas

### DIFF
--- a/serverless/src/index.ts
+++ b/serverless/src/index.ts
@@ -43,6 +43,7 @@ export interface FunctionProperties {
   Layers?: string[];
   TracingConfig?: { [key: string]: string };
   FunctionName?: string;
+  Architectures?: [string];
 }
 
 export const handler = async (event: InputEvent, _: any) => {

--- a/serverless/src/layer.ts
+++ b/serverless/src/layer.ts
@@ -72,7 +72,7 @@ function runtimeToLayerName(runtime: string, architecture: string): string {
     return nodeLookup[runtime];
   }
 
-  if (runtimeLookup[runtime] === RuntimeType.PYTHON && architctureLookup[architecture] === ArchitectureType.ARM64) {
+  if (runtimeLookup[runtime] === RuntimeType.PYTHON && architectureLookup[architecture] === ArchitectureType.ARM64) {
     return pythonArmLookup[runtime];
   }
 

--- a/serverless/src/layer.ts
+++ b/serverless/src/layer.ts
@@ -184,8 +184,8 @@ function addLayer(layerArn: string, lambda: LambdaFunction) {
   }
 }
 
-export function getLambdaLibraryLayerArn(region: string, version: number, runtime: string, architcture: string) {
-  const layerName = runtimeToLayerName(runtime, architcture);
+export function getLambdaLibraryLayerArn(region: string, version: number, runtime: string, architecture: string) {
+  const layerName = runtimeToLayerName(runtime, architecture);
   const isGovCloud = region === "us-gov-east-1" || region === "us-gov-west-1";
 
   // if this is a GovCloud region, use the GovCloud lambda layer

--- a/serverless/src/layer.ts
+++ b/serverless/src/layer.ts
@@ -104,8 +104,8 @@ export function findLambdas(resources: Resources) {
       if (runtime !== undefined && runtime in runtimeLookup) {
         runtimeType = runtimeLookup[runtime];
       }
-      if (architecture !== undefined && architecture in architctureLookup) {
-        architectureType = architctureLookup[architecture];
+      if (architecture !== undefined && architecture in architectureLookup) {
+        architectureType = architectureLookup[architecture];
       }
 
       return {

--- a/serverless/src/layer.ts
+++ b/serverless/src/layer.ts
@@ -27,7 +27,7 @@ export interface LambdaFunction {
   architecture: string;
 }
 
-const architctureLookup: { [key: string]: ArchitectureType } = {
+const architectureLookup: { [key: string]: ArchitectureType } = {
   "x86_64": ArchitectureType.x86_64,
   "arm64": ArchitectureType.ARM64,
 };

--- a/serverless/src/layer.ts
+++ b/serverless/src/layer.ts
@@ -197,7 +197,7 @@ export function getLambdaLibraryLayerArn(region: string, version: number, runtim
 }
 
 export function getExtensionLayerArn(region: string, version: number, architecture: string) {
-  let layerName = architectureToExtensionLayerName[architecture];
+  const layerName = architectureToExtensionLayerName[architecture];
 
   const isGovCloud = region === "us-gov-east-1" || region === "us-gov-west-1";
 

--- a/serverless/test/env.spec.ts
+++ b/serverless/test/env.spec.ts
@@ -5,7 +5,7 @@ import {
   setEnvConfiguration,
   validateParameters,
 } from "../src/env";
-import { LambdaFunction, RuntimeType } from "../src/layer";
+import { ArchitectureType, LambdaFunction, RuntimeType } from "../src/layer";
 
 describe("getConfig", () => {
   it("correctly parses parameters from Mappings", () => {
@@ -54,6 +54,8 @@ describe("setEnvConfiguration", () => {
       key: "FunctionKey",
       runtimeType: RuntimeType.PYTHON,
       runtime: "python2.7",
+      architecture: "x86_64",
+      architectureType: ArchitectureType.x86_64
     };
     const config = {
       addLayers: false,
@@ -105,6 +107,8 @@ describe("setEnvConfiguration", () => {
       key: "FunctionKey",
       runtimeType: RuntimeType.PYTHON,
       runtime: "python2.7",
+      architecture: "x86_64",
+      architectureType: ArchitectureType.x86_64
     };
     const config = {
       addLayers: false,
@@ -137,6 +141,8 @@ describe("setEnvConfiguration", () => {
       key: "FunctionKey",
       runtimeType: RuntimeType.PYTHON,
       runtime: "python2.7",
+      architecture: "x86_64",
+      architectureType: ArchitectureType.x86_64
     };
     const config = {
       addLayers: false,
@@ -177,6 +183,8 @@ describe("setEnvConfiguration", () => {
       key: "FunctionKey",
       runtimeType: RuntimeType.PYTHON,
       runtime: "python2.7",
+      architecture: "x86_64",
+      architectureType: ArchitectureType.x86_64
     };
     const config = {
       addLayers: false,

--- a/serverless/test/layer.spec.ts
+++ b/serverless/test/layer.spec.ts
@@ -8,20 +8,22 @@ import {
   getMissingLayerVersionErrorMsg,
   getLambdaLibraryLayerArn,
   getExtensionLayerArn,
+  ArchitectureType,
 } from "../src/layer";
 
-function mockFunctionResource(runtime: string) {
+function mockFunctionResource(runtime: string, architectures?: string[]) {
   return {
     Type: "AWS::Lambda::Function",
     Properties: {
       Handler: "app.handler",
       Role: "role-arn",
       Runtime: runtime,
+      Architectures: architectures
     },
   };
 }
 
-function mockLambdaFunction(key: string, runtime: string, runtimeType: RuntimeType) {
+function mockLambdaFunction(key: string, runtime: string, runtimeType: RuntimeType, architecture: string = "x86_64", architectureType: ArchitectureType = ArchitectureType.x86_64) {
   return {
     properties: {
       Handler: "app.handler",
@@ -31,6 +33,8 @@ function mockLambdaFunction(key: string, runtime: string, runtimeType: RuntimeTy
     key,
     runtimeType,
     runtime,
+    architecture,
+    architectureType
   } as LambdaFunction;
 }
 
@@ -174,28 +178,42 @@ describe("getLambdaLibraryLayerArn", () => {
     const region = "us-east-1";
     const version = 22;
     const runtime = "nodejs14.x";
-    const layerArn = getLambdaLibraryLayerArn(region, version, runtime);
+    const layerArn = getLambdaLibraryLayerArn(region, version, runtime, "x86_64");
     expect(layerArn).toEqual(`arn:aws:lambda:${region}:${DD_ACCOUNT_ID}:layer:Datadog-Node14-x:${version}`);
   });
   it("gets the us-east-1 layer arn for the Datadog Python36 Lambda Library", () => {
     const region = "us-east-1";
     const version = 22;
     const runtime = "python3.6";
-    const layerArn = getLambdaLibraryLayerArn(region, version, runtime);
+    const layerArn = getLambdaLibraryLayerArn(region, version, runtime, "x86_64");
     expect(layerArn).toEqual(`arn:aws:lambda:${region}:${DD_ACCOUNT_ID}:layer:Datadog-Python36:${version}`);
+  });
+  it("gets the us-east-1 ARM layer arn for the Datadog Python38 Lambda Library", () => {
+    const region = "us-east-1";
+    const version = 22;
+    const runtime = "python3.8";
+    const layerArn = getLambdaLibraryLayerArn(region, version, runtime, "arm64");
+    expect(layerArn).toEqual(`arn:aws:lambda:${region}:${DD_ACCOUNT_ID}:layer:Datadog-Python38-ARM:${version}`);
   });
   it("gets the us-gov-east-1 layer arn for the Datadog Python36 Lambda Library", () => {
     const region = "us-gov-east-1";
     const version = 22;
     const runtime = "python3.6";
-    const layerArn = getLambdaLibraryLayerArn(region, version, runtime);
+    const layerArn = getLambdaLibraryLayerArn(region, version, runtime, "x86_64");
     expect(layerArn).toEqual(`arn:aws-us-gov:lambda:${region}:${DD_GOV_ACCOUNT_ID}:layer:Datadog-Python36:${version}`);
+  });
+  it("gets the us-gov-east-1 ARM layer arn for the Datadog Python39 Lambda Library", () => {
+    const region = "us-gov-east-1";
+    const version = 22;
+    const runtime = "python3.9";
+    const layerArn = getLambdaLibraryLayerArn(region, version, runtime, "arm64");
+    expect(layerArn).toEqual(`arn:aws-us-gov:lambda:${region}:${DD_GOV_ACCOUNT_ID}:layer:Datadog-Python39-ARM:${version}`);
   });
   it("gets the us-gov-east-1 layer arn for the Datadog Node14 Lambda Library", () => {
     const region = "us-gov-east-1";
     const version = 22;
     const runtime = "nodejs14.x";
-    const layerArn = getLambdaLibraryLayerArn(region, version, runtime);
+    const layerArn = getLambdaLibraryLayerArn(region, version, runtime, "x86_64");
     expect(layerArn).toEqual(`arn:aws-us-gov:lambda:${region}:${DD_GOV_ACCOUNT_ID}:layer:Datadog-Node14-x:${version}`);
   });
 });
@@ -204,13 +222,25 @@ describe("getExtensionLayerArn", () => {
   it("gets the us-east-1 layer arn for the Datadog Lambda Extension", () => {
     const region = "us-east-1";
     const version = 6;
-    const layerArn = getExtensionLayerArn(region, version);
+    const layerArn = getExtensionLayerArn(region, version, "x86_64");
     expect(layerArn).toEqual(`arn:aws:lambda:${region}:${DD_ACCOUNT_ID}:layer:Datadog-Extension:${version}`);
+  });
+  it("gets the us-east-1 layer arn for the ARM Datadog Lambda Extension", () => {
+    const region = "us-east-1";
+    const version = 6;
+    const layerArn = getExtensionLayerArn(region, version, "arm64");
+    expect(layerArn).toEqual(`arn:aws:lambda:${region}:${DD_ACCOUNT_ID}:layer:Datadog-Extension-ARM:${version}`);
   });
   it("gets the us-gov-west-1 layer arn for the Datadog Lambda Extension", () => {
     const region = "us-gov-west-1";
     const version = 6;
-    const layerArn = getExtensionLayerArn(region, version);
+    const layerArn = getExtensionLayerArn(region, version, "x86_64");
     expect(layerArn).toEqual(`arn:aws-us-gov:lambda:${region}:${DD_GOV_ACCOUNT_ID}:layer:Datadog-Extension:${version}`);
+  });
+  it("gets the us-gov-west-1 layer arn for the ARM Datadog Lambda Extension", () => {
+    const region = "us-gov-west-1";
+    const version = 6;
+    const layerArn = getExtensionLayerArn(region, version, "arm64");
+    expect(layerArn).toEqual(`arn:aws-us-gov:lambda:${region}:${DD_GOV_ACCOUNT_ID}:layer:Datadog-Extension-ARM:${version}`);
   });
 });

--- a/serverless/test/layer.spec.ts
+++ b/serverless/test/layer.spec.ts
@@ -142,6 +142,20 @@ describe("applyLayers", () => {
     ]);
   });
 
+  it("applies the node and extension lambda layers for arm", () => {
+    const lambda = mockLambdaFunction("FunctionKey", "nodejs12.x", RuntimeType.NODE, "arm64", ArchitectureType.ARM64);
+    const region = "us-east-1";
+    const nodeLayerVersion = 25;
+    const extensionLayerVersion = 6;
+    const errors = applyLayers(region, [lambda], undefined, nodeLayerVersion, extensionLayerVersion);
+
+    expect(errors.length).toEqual(0);
+    expect(lambda.properties.Layers).toEqual([
+      `arn:aws:lambda:${region}:${DD_ACCOUNT_ID}:layer:Datadog-Node12-x:${nodeLayerVersion}`,
+      `arn:aws:lambda:${region}:${DD_ACCOUNT_ID}:layer:Datadog-Extension-ARM:${extensionLayerVersion}`,
+    ]);
+  });
+
   it("applies the python and extension lambda layers", () => {
     const lambda = mockLambdaFunction("FunctionKey", "python3.6", RuntimeType.PYTHON);
     const region = "us-east-1";
@@ -153,6 +167,20 @@ describe("applyLayers", () => {
     expect(lambda.properties.Layers).toEqual([
       `arn:aws:lambda:${region}:${DD_ACCOUNT_ID}:layer:Datadog-Python36:${pythonLayerVersion}`,
       `arn:aws:lambda:${region}:${DD_ACCOUNT_ID}:layer:Datadog-Extension:${extensionLayerVersion}`,
+    ]);
+  });
+
+  it("applies the python and extension lambda layers for arm", () => {
+    const lambda = mockLambdaFunction("FunctionKey", "python3.9", RuntimeType.PYTHON, "arm64", ArchitectureType.ARM64);
+    const region = "us-east-1";
+    const pythonLayerVersion = 25;
+    const extensionLayerVersion = 6;
+    const errors = applyLayers(region, [lambda], pythonLayerVersion, undefined, extensionLayerVersion);
+
+    expect(errors.length).toEqual(0);
+    expect(lambda.properties.Layers).toEqual([
+      `arn:aws:lambda:${region}:${DD_ACCOUNT_ID}:layer:Datadog-Python39:${pythonLayerVersion}`,
+      `arn:aws:lambda:${region}:${DD_ACCOUNT_ID}:layer:Datadog-Extension-ARM:${extensionLayerVersion}`,
     ]);
   });
 });

--- a/serverless/test/layer.spec.ts
+++ b/serverless/test/layer.spec.ts
@@ -179,7 +179,7 @@ describe("applyLayers", () => {
 
     expect(errors.length).toEqual(0);
     expect(lambda.properties.Layers).toEqual([
-      `arn:aws:lambda:${region}:${DD_ACCOUNT_ID}:layer:Datadog-Python39:${pythonLayerVersion}`,
+      `arn:aws:lambda:${region}:${DD_ACCOUNT_ID}:layer:Datadog-Python39-ARM:${pythonLayerVersion}`,
       `arn:aws:lambda:${region}:${DD_ACCOUNT_ID}:layer:Datadog-Extension-ARM:${extensionLayerVersion}`,
     ]);
   });

--- a/serverless/test/tracing.spec.ts
+++ b/serverless/test/tracing.spec.ts
@@ -1,5 +1,5 @@
 import { enableTracing, TracingMode, IamRoleProperties, MissingIamRoleError } from "../src/tracing";
-import { LambdaFunction, RuntimeType } from "../src/layer";
+import { ArchitectureType, LambdaFunction, RuntimeType } from "../src/layer";
 
 function mockLambdaFunction() {
   return {
@@ -15,6 +15,8 @@ function mockLambdaFunction() {
     key: "HelloWorldFunction",
     runtimeType: RuntimeType.NODE,
     runtime: "nodejs10.x",
+    architecture: "x86_64",
+    architectureType: ArchitectureType.x86_64
   } as LambdaFunction;
 }
 
@@ -144,6 +146,8 @@ describe("enableTracing", () => {
       key: "HelloWorldFunction",
       runtimeType: RuntimeType.NODE,
       runtime: "nodejs10.x",
+      architecture: "x86_64",
+      architectureType: ArchitectureType.x86_64
     };
     const resources: Record<string, any> = {
       HelloWorldFunction: {


### PR DESCRIPTION
#48

### What does this PR do?

I added support for Lambdas running on arm64 based architectures

### Motivation

The current macro adds the x86_64 layers to functions which caused our new arm based functions to fail

### Testing Guidelines

I added unit tests

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
