### PR TITLE
Add ref support to retrieve runtime & architecture in findLambdas

### DIFF
--- a/serverless/src/index.ts
+++ b/serverless/src/index.ts
@@ -11,6 +11,8 @@ import log from "loglevel";
 const SUCCESS = "success";
 const FAILURE = "failure";
 
+export type Parameters = { [key: string]: any }
+
 export interface Resources {
   [logicalId: string]: {
     Type: string;
@@ -28,9 +30,9 @@ export interface InputEvent {
   accountId: string;
   fragment: CfnTemplate;
   transformId: string; // Name of the macro
-  params: { [key: string]: any };
+  params: Parameters;
   requestId: string;
-  templateParameterValues: { [key: string]: any };
+  templateParameterValues: Parameters;
 }
 
 export interface FunctionProperties {
@@ -77,7 +79,7 @@ export const handler = async (event: InputEvent, _: any) => {
       };
     }
 
-    const lambdas = findLambdas(resources);
+    const lambdas = findLambdas(resources, event.templateParameterValues);
     log.debug(`Lambda resources found: ${JSON.stringify(lambdas)}`);
 
     log.debug("Setting environment variables for Lambda function resources");

--- a/serverless/test/layer.spec.ts
+++ b/serverless/test/layer.spec.ts
@@ -11,7 +11,7 @@ import {
   ArchitectureType,
 } from "../src/layer";
 
-function mockFunctionResource(runtime: string, architectures?: string[]) {
+function mockFunctionResource(runtime: string | { Ref: string }, architectures?: string[]) {
   return {
     Type: "AWS::Lambda::Function",
     Properties: {
@@ -29,12 +29,14 @@ function mockLambdaFunction(
   runtimeType: RuntimeType,
   architecture: string,
   architectureType: ArchitectureType = ArchitectureType.x86_64,
+  runtimeProperty?: { Ref: string },
 ) {
   return {
     properties: {
       Handler: "app.handler",
-      Runtime: runtime,
+      Runtime: runtimeProperty ?? runtime,
       Role: "role-arn",
+      Architectures: [architecture],
     },
     key,
     runtimeType,
@@ -47,28 +49,32 @@ function mockLambdaFunction(
 describe("findLambdas", () => {
   it("finds lambdas and correctly assigns runtime types", () => {
     const resources = {
-      Node10Function: mockFunctionResource("nodejs10.x"),
-      Node12Function: mockFunctionResource("nodejs12.x"),
-      Node14Function: mockFunctionResource("nodejs14.x"),
-      Python27Function: mockFunctionResource("python2.7"),
-      Python36Function: mockFunctionResource("python3.6"),
-      Python37Function: mockFunctionResource("python3.7"),
-      Python38Function: mockFunctionResource("python3.8"),
-      Python39Function: mockFunctionResource("python3.9"),
-      GoFunction: mockFunctionResource("go1.10"),
+      Node10Function: mockFunctionResource("nodejs10.x", ["x86_64"]),
+      Node12Function: mockFunctionResource("nodejs12.x", ["x86_64"]),
+      Node14Function: mockFunctionResource("nodejs14.x", ["x86_64"]),
+      Python27Function: mockFunctionResource("python2.7", ["x86_64"]),
+      Python36Function: mockFunctionResource("python3.6", ["x86_64"]),
+      Python37Function: mockFunctionResource("python3.7", ["x86_64"]),
+      Python38Function: mockFunctionResource("python3.8", ["x86_64"]),
+      Python39Function: mockFunctionResource("python3.9", ["x86_64"]),
+      GoFunction: mockFunctionResource("go1.10", ["x86_64"]),
+      RefFunction: mockFunctionResource({ Ref: "ValueRef" }, ["arm64"]),
     };
-    const lambdas = findLambdas(resources);
+    const lambdas = findLambdas(resources, { ValueRef: "nodejs14.x" });
 
     expect(lambdas).toEqual([
-      mockLambdaFunction("Node10Function", "nodejs10.x", RuntimeType.NODE, "x86_64"),
-      mockLambdaFunction("Node12Function", "nodejs12.x", RuntimeType.NODE, "x86_64"),
-      mockLambdaFunction("Node14Function", "nodejs14.x", RuntimeType.NODE, "x86_64"),
-      mockLambdaFunction("Python27Function", "python2.7", RuntimeType.PYTHON, "x86_64"),
-      mockLambdaFunction("Python36Function", "python3.6", RuntimeType.PYTHON, "x86_64"),
-      mockLambdaFunction("Python37Function", "python3.7", RuntimeType.PYTHON, "x86_64"),
-      mockLambdaFunction("Python38Function", "python3.8", RuntimeType.PYTHON, "x86_64"),
-      mockLambdaFunction("Python39Function", "python3.9", RuntimeType.PYTHON, "x86_64"),
-      mockLambdaFunction("GoFunction", "go1.10", RuntimeType.UNSUPPORTED, "x86_64"),
+      mockLambdaFunction("Node10Function", "nodejs10.x", RuntimeType.NODE, "x86_64", ArchitectureType.x86_64),
+      mockLambdaFunction("Node12Function", "nodejs12.x", RuntimeType.NODE, "x86_64", ArchitectureType.x86_64),
+      mockLambdaFunction("Node14Function", "nodejs14.x", RuntimeType.NODE, "x86_64", ArchitectureType.x86_64),
+      mockLambdaFunction("Python27Function", "python2.7", RuntimeType.PYTHON, "x86_64", ArchitectureType.x86_64),
+      mockLambdaFunction("Python36Function", "python3.6", RuntimeType.PYTHON, "x86_64", ArchitectureType.x86_64),
+      mockLambdaFunction("Python37Function", "python3.7", RuntimeType.PYTHON, "x86_64", ArchitectureType.x86_64),
+      mockLambdaFunction("Python38Function", "python3.8", RuntimeType.PYTHON, "x86_64", ArchitectureType.x86_64),
+      mockLambdaFunction("Python39Function", "python3.9", RuntimeType.PYTHON, "x86_64", ArchitectureType.x86_64),
+      mockLambdaFunction("GoFunction", "go1.10", RuntimeType.UNSUPPORTED, "x86_64", ArchitectureType.x86_64),
+      mockLambdaFunction("RefFunction", "nodejs14.x", RuntimeType.NODE, "arm64", ArchitectureType.ARM64, {
+        Ref: "ValueRef",
+      }),
     ]);
   });
 });


### PR DESCRIPTION
### What does this PR do?

This PR allows to handle correctly runtime and architecture values if these values use Ref intrinsic function.

### Motivation

We needed to override findLambdas to handle our usage, this may be useful to others.

### Testing Guidelines

Tested by unit tests and deployments in our environments.

### Additional Notes

N/A

### Types of changes

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [X] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [X] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
