### PR TITLE
Revert Tag Formatting to JSON Object Arrays

### DIFF
--- a/serverless/src/index.ts
+++ b/serverless/src/index.ts
@@ -41,7 +41,7 @@ export interface FunctionProperties {
   Role: string | { [func: string]: string[] };
   Code: any;
   Environment?: { Variables?: { [key: string]: string | boolean } };
-  Tags?: { [key: string]: string };
+  Tags?: { Key: string; Value: string }[];
   Layers?: string[];
   TracingConfig?: { [key: string]: string };
   FunctionName?: string;

--- a/serverless/test/index.spec.ts
+++ b/serverless/test/index.spec.ts
@@ -107,7 +107,12 @@ function mockInputEvent(
   }
 
   if (fromSAM) {
-    fragment.Resources.HelloWorldFunction.Properties.Tags = { "lambda:createdBy": "SAM" };
+    fragment.Resources.HelloWorldFunction.Properties.Tags = [
+      {
+        Key: "lambda:createdBy",
+        Value: "SAM",
+      },
+    ];
   }
 
   return {
@@ -244,7 +249,7 @@ describe("Macro", () => {
       const output = await handler(inputEvent, {});
       const lambdaProperties: FunctionProperties = output.fragment.Resources[LAMBDA_KEY].Properties;
 
-      expect(lambdaProperties.Tags).toEqual({ dd_sls_macro: expect.stringMatching(VERSION_REGEX) });
+      expect(lambdaProperties.Tags).toEqual([{ Key: "dd_sls_macro", Value: expect.stringMatching(VERSION_REGEX) }]);
     });
 
     it("only adds cdk created tag when CDKMetadata is present", async () => {
@@ -253,10 +258,10 @@ describe("Macro", () => {
       const output = await handler(inputEvent, {});
       const lambdaProperties: FunctionProperties = output.fragment.Resources[LAMBDA_KEY].Properties;
 
-      expect(lambdaProperties.Tags).toEqual({
-        dd_sls_macro: expect.stringMatching(VERSION_REGEX),
-        dd_sls_macro_by: "CDK",
-      });
+      expect(lambdaProperties.Tags).toEqual([
+        { Key: "dd_sls_macro", Value: expect.stringMatching(VERSION_REGEX) },
+        { Key: "dd_sls_macro_by", Value: "CDK" },
+      ]);
     });
 
     it("only adds SAM created tag when lambda:createdBy:SAM tag is present", async () => {
@@ -265,11 +270,11 @@ describe("Macro", () => {
       const output = await handler(inputEvent, {});
       const lambdaProperties: FunctionProperties = output.fragment.Resources[LAMBDA_KEY].Properties;
 
-      expect(lambdaProperties.Tags).toEqual({
-        "lambda:createdBy": "SAM",
-        dd_sls_macro: expect.stringMatching(VERSION_REGEX),
-        dd_sls_macro_by: "SAM",
-      });
+      expect(lambdaProperties.Tags).toEqual([
+        { Key: "lambda:createdBy", Value: "SAM" },
+        { Key: "dd_sls_macro", Value: expect.stringMatching(VERSION_REGEX) },
+        { Key: "dd_sls_macro_by", Value: "SAM" },
+      ]);
     });
 
     it("adds tags if tag params are provided and forwarderArn is set", async () => {
@@ -286,14 +291,14 @@ describe("Macro", () => {
       const output = await handler(inputEvent, {});
       const lambdaProperties: FunctionProperties = output.fragment.Resources[LAMBDA_KEY].Properties;
 
-      expect(lambdaProperties.Tags).toEqual({
-        service: "my-service",
-        env: "test",
-        version: "1",
-        team: "avengers",
-        project: "marvel",
-        dd_sls_macro: expect.stringMatching(VERSION_REGEX),
-      });
+      expect(lambdaProperties.Tags).toEqual([
+        { Key: "service", Value: "my-service" },
+        { Key: "env", Value: "test" },
+        { Key: "version", Value: "1" },
+        { Key: "team", Value: "avengers" },
+        { Key: "project", Value: "marvel" },
+        { Key: "dd_sls_macro", Value: expect.stringMatching(VERSION_REGEX) },
+      ]);
     });
 
     it("doesn't add tags if tags params are provided but forwarderArn is not set", async () => {
@@ -308,7 +313,7 @@ describe("Macro", () => {
       const output = await handler(inputEvent, {});
       const lambdaProperties: FunctionProperties = output.fragment.Resources[LAMBDA_KEY].Properties;
 
-      expect(lambdaProperties.Tags).toEqual({ dd_sls_macro: expect.stringMatching(VERSION_REGEX) });
+      expect(lambdaProperties.Tags).toEqual([{ Key: "dd_sls_macro", Value: expect.stringMatching(VERSION_REGEX) }]);
     });
   });
 });

--- a/serverless/test/tags.spec.ts
+++ b/serverless/test/tags.spec.ts
@@ -2,13 +2,13 @@ import { defaultConfiguration } from "../src/env";
 import { RuntimeType, LambdaFunction } from "../src/layer";
 import { addDDTags, addMacroTag, addCDKTag, addSAMTag } from "../src/tags";
 
-function mockLambdaFunction(tags: { [key: string]: string } | undefined) {
+function mockLambdaFunction(tags: { Key: string; Value: string }[]) {
   return {
     properties: {
       Handler: "app.handler",
       Runtime: "nodejs12.x",
       Role: "role-arn",
-      Tags: { ...tags },
+      Tags: [...tags],
     },
     key: "FunctionKey",
     runtimeType: RuntimeType.NODE,
@@ -25,18 +25,23 @@ describe("addDDTags", () => {
       version: "1",
       tags: "team:avengers,project:marvel",
     };
-    const existingTags = { env: "dev", service: "my-service", version: "2", team: "serverless" };
+    const existingTags = [
+      { Key: "env", Value: "dev" },
+      { Key: "service", Value: "my-service" },
+      { Key: "version", Value: "2" },
+      { Key: "team", Value: "serverless" },
+    ];
     const lambda = mockLambdaFunction(existingTags);
     addDDTags([lambda], config);
 
-    expect(lambda.properties.Tags).toEqual({ ...existingTags, project: "marvel" });
+    expect(lambda.properties.Tags).toEqual([...existingTags, { Key: "project", Value: "marvel" }]);
   });
 
   it("does not add tags if provided config doesn't have tags", () => {
-    const lambda = mockLambdaFunction(undefined);
+    const lambda = mockLambdaFunction([]);
     addDDTags([lambda], defaultConfiguration);
 
-    expect(lambda.properties.Tags).toEqual({});
+    expect(lambda.properties.Tags).toEqual([]);
   });
 
   it("creates tags property if needed", () => {
@@ -47,16 +52,16 @@ describe("addDDTags", () => {
       version: "1",
       tags: "team:avengers,project:marvel",
     };
-    const lambda = mockLambdaFunction(undefined);
+    const lambda = mockLambdaFunction([]);
     addDDTags([lambda], config);
 
-    expect(lambda.properties.Tags).toEqual({
-      service: "my-service",
-      env: "test",
-      version: "1",
-      team: "avengers",
-      project: "marvel",
-    });
+    expect(lambda.properties.Tags).toEqual([
+      { Key: "service", Value: "my-service" },
+      { Key: "env", Value: "test" },
+      { Key: "version", Value: "1" },
+      { Key: "team", Value: "avengers" },
+      { Key: "project", Value: "marvel" },
+    ]);
   });
 
   it("adds to existing tags property if needed", () => {
@@ -66,23 +71,26 @@ describe("addDDTags", () => {
       version: "1",
       tags: "team:avengers",
     };
-    const existingTags = { env: "dev", project: "lambda" };
+    const existingTags = [
+      { Key: "env", Value: "dev" },
+      { Key: "project", Value: "lambda" },
+    ];
     const lambda = mockLambdaFunction(existingTags);
     addDDTags([lambda], config);
 
-    expect(lambda.properties.Tags).toEqual({
-      env: "dev",
-      project: "lambda",
-      service: "my-service",
-      version: "1",
-      team: "avengers",
-    });
+    expect(lambda.properties.Tags).toEqual([
+      { Key: "env", Value: "dev" },
+      { Key: "project", Value: "lambda" },
+      { Key: "service", Value: "my-service" },
+      { Key: "version", Value: "1" },
+      { Key: "team", Value: "avengers" },
+    ]);
   });
 });
 
 describe("addMacroTag", () => {
   it("does not update tags if no version is passed in", () => {
-    const existingTags = { band: "ironmaiden" };
+    const existingTags = [{ Key: "band", Value: "ironmaiden" }];
     const lambda = mockLambdaFunction(existingTags);
     addMacroTag([lambda], undefined);
 
@@ -90,60 +98,60 @@ describe("addMacroTag", () => {
   });
 
   it("creates tags property if needed", () => {
-    const lambda = mockLambdaFunction(undefined);
+    const lambda = mockLambdaFunction([]);
     addMacroTag([lambda], "6.6.6");
 
-    expect(lambda.properties.Tags).toEqual({ dd_sls_macro: "v6.6.6" });
+    expect(lambda.properties.Tags).toEqual([{ Key: "dd_sls_macro", Value: "v6.6.6" }]);
   });
 
   it("appends version tag if needed", () => {
-    const existingTags = { env: "dev" };
+    const existingTags = [{ Key: "env", Value: "dev" }];
     const lambda = mockLambdaFunction(existingTags);
     addMacroTag([lambda], "6.6.6");
 
-    expect(lambda.properties.Tags).toEqual({
-      env: "dev",
-      dd_sls_macro: "v6.6.6",
-    });
+    expect(lambda.properties.Tags).toEqual([
+      { Key: "env", Value: "dev" },
+      { Key: "dd_sls_macro", Value: "v6.6.6" },
+    ]);
   });
 });
 
 describe("addCDKTag", () => {
   it("creates tags property if needed", () => {
-    const lambda = mockLambdaFunction(undefined);
+    const lambda = mockLambdaFunction([]);
     addCDKTag([lambda]);
 
-    expect(lambda.properties.Tags).toEqual({ dd_sls_macro_by: "CDK" });
+    expect(lambda.properties.Tags).toEqual([{ Key: "dd_sls_macro_by", Value: "CDK" }]);
   });
 
   it("appends version tag if needed", () => {
-    const existingTags = { env: "dev" };
+    const existingTags = [{ Key: "env", Value: "dev" }];
     const lambda = mockLambdaFunction(existingTags);
     addCDKTag([lambda]);
 
-    expect(lambda.properties.Tags).toEqual({
-      env: "dev",
-      dd_sls_macro_by: "CDK",
-    });
+    expect(lambda.properties.Tags).toEqual([
+      { Key: "env", Value: "dev" },
+      { Key: "dd_sls_macro_by", Value: "CDK" },
+    ]);
   });
 });
 
 describe("addSAMTag", () => {
   it("creates tags property if needed", () => {
-    const lambda = mockLambdaFunction(undefined);
+    const lambda = mockLambdaFunction([]);
     addSAMTag([lambda]);
 
-    expect(lambda.properties.Tags).toEqual({});
+    expect(lambda.properties.Tags).toEqual([]);
   });
 
   it("appends version tag if needed", () => {
-    const existingTags = { "lambda:createdBy": "SAM" };
+    const existingTags = [{ Key: "lambda:createdBy", Value: "SAM" }];
     const lambda = mockLambdaFunction(existingTags);
     addSAMTag([lambda]);
 
-    expect(lambda.properties.Tags).toEqual({
-      "lambda:createdBy": "SAM",
-      dd_sls_macro_by: "SAM",
-    });
+    expect(lambda.properties.Tags).toEqual([
+      { Key: "lambda:createdBy", Value: "SAM" },
+      { Key: "dd_sls_macro_by", Value: "SAM" },
+    ]);
   });
 });


### PR DESCRIPTION
### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->
In a [previous PR](https://github.com/DataDog/datadog-cloudformation-macro/pull/63) to add DD_XXX env vars and tagging, I modified the tag formatting to be `{ [key: string]: string };` instead of `{ Key: string; Value: string }[];` but cloudformation requires the JSON object array for Tags so this PR reverts that change. 

### Motivation

<!--- What inspired you to submit this pull request? --->
Problem was reported [here](https://github.com/DataDog/datadog-cloudformation-macro/issues/64)

### Testing Guidelines

<!--- How did you test this pull request? --->
Updated all unit tests to what we now expect and everything seems to be passing and looking good 

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
