### PR TITLE
Honor DD_MERGE_XRAY_TRACES from Function Environment

### DIFF
--- a/serverless/src/tracing.ts
+++ b/serverless/src/tracing.ts
@@ -125,7 +125,10 @@ export function enableTracing(tracingMode: TracingMode, lambdas: LambdaFunction[
       const envVariables = environment.Variables ?? {};
 
       envVariables[DD_TRACE_ENABLED] = true;
-      envVariables[DD_MERGE_XRAY_TRACES] = tracingMode === TracingMode.HYBRID;
+      // If this is already defined, honor it. Otherwise, configure it
+      if (!(DD_MERGE_XRAY_TRACES in envVariables)) {
+        envVariables[DD_MERGE_XRAY_TRACES] = tracingMode === TracingMode.HYBRID;
+      }
 
       environment.Variables = envVariables;
       lambda.properties.Environment = environment;


### PR DESCRIPTION
### What does this PR do?
When using the default values, if X-Ray Tracing is being managed separately from the DataDog Serverless Macro, keep the existing value.

This at least partially resolves #69 by keeping the Environment Variable from the template if you ONLY enable DataDog Tracking through the Macro, leaving X-Ray Tracing to be unaffected

### Motivation

This is blocking our use of the newer version of the Datadog Serverless Macro

### Testing Guidelines

Updated tracing.spec.ts with an example resource based on the actual resource generated in CloudFormation.
Added unit test for this specific scenario.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [X] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
