### PR TITLE
fixing the override of trace config on a function level

### DIFF
--- a/serverless/src/tracing.ts
+++ b/serverless/src/tracing.ts
@@ -123,7 +123,7 @@ export function enableTracing(tracingMode: TracingMode, lambdas: LambdaFunction[
     lambdas.forEach((lambda) => {
       const environment = lambda.properties.Environment ?? {};
       const envVariables = environment.Variables ?? {};
-      if (!envVariables.hasOwnProperty(DD_TRACE_ENABLED)) {
+      if (!(DD_TRACE_ENABLED in envVariables))  {                  
         envVariables[DD_TRACE_ENABLED] = true;
         log.debug(`${lambda.properties.FunctionName} skipped as DD_TRACE_ENABLED was defined on a function level`);
       }

--- a/serverless/src/tracing.ts
+++ b/serverless/src/tracing.ts
@@ -125,6 +125,7 @@ export function enableTracing(tracingMode: TracingMode, lambdas: LambdaFunction[
       const envVariables = environment.Variables ?? {};
       if (!envVariables.hasOwnProperty(DD_TRACE_ENABLED)) {
         envVariables[DD_TRACE_ENABLED] = true;
+        log.debug(`${lambda.properties.FunctionName} skipped as DD_TRACE_ENABLED was defined on a function level`);
       }
       envVariables[DD_MERGE_XRAY_TRACES] = tracingMode === TracingMode.HYBRID;
 

--- a/serverless/src/tracing.ts
+++ b/serverless/src/tracing.ts
@@ -123,7 +123,7 @@ export function enableTracing(tracingMode: TracingMode, lambdas: LambdaFunction[
     lambdas.forEach((lambda) => {
       const environment = lambda.properties.Environment ?? {};
       const envVariables = environment.Variables ?? {};
-      if (!(DD_TRACE_ENABLED in envVariables))  {                  
+      if (!(DD_TRACE_ENABLED in envVariables)) {
         envVariables[DD_TRACE_ENABLED] = true;
         log.debug(`${lambda.properties.FunctionName} skipped as DD_TRACE_ENABLED was defined on a function level`);
       }

--- a/serverless/src/tracing.ts
+++ b/serverless/src/tracing.ts
@@ -123,8 +123,9 @@ export function enableTracing(tracingMode: TracingMode, lambdas: LambdaFunction[
     lambdas.forEach((lambda) => {
       const environment = lambda.properties.Environment ?? {};
       const envVariables = environment.Variables ?? {};
-
-      envVariables[DD_TRACE_ENABLED] = true;
+      if (!envVariables.hasOwnProperty(DD_TRACE_ENABLED)) {
+        envVariables[DD_TRACE_ENABLED] = true;
+      }
       envVariables[DD_MERGE_XRAY_TRACES] = tracingMode === TracingMode.HYBRID;
 
       environment.Variables = envVariables;

--- a/serverless/test/tracing.spec.ts
+++ b/serverless/test/tracing.spec.ts
@@ -35,7 +35,7 @@ function mockLambdaFunctionWithPreDefinedTraceSetting() {
           DD_TRACE_ENABLED: false,
         },
       },
-    },    
+    },
     key: "HelloWorldFunction",
     runtimeType: RuntimeType.NODE,
     runtime: "nodejs16.x",
@@ -123,11 +123,11 @@ describe("enableTracing", () => {
 
   it("dd tracing enabled but should not override a funciton with a predefined trace setting", () => {
     const tracingMode = TracingMode.DD_TRACE;
-    const lambdaWithFunctionLevelTraceSetting = mockLambdaFunctionWithPreDefinedTraceSetting();    
+    const lambdaWithFunctionLevelTraceSetting = mockLambdaFunctionWithPreDefinedTraceSetting();
     const lambdaWithOutTraceSetting = mockLambdaFunction();
     const resources: Record<string, any> = mockResources();
     const iamRole: IamRoleProperties = resources.HelloWorldFunctionRole.Properties;
-    enableTracing(tracingMode, [lambdaWithFunctionLevelTraceSetting,lambdaWithOutTraceSetting], resources);
+    enableTracing(tracingMode, [lambdaWithFunctionLevelTraceSetting, lambdaWithOutTraceSetting], resources);
 
     expect(lambdaWithFunctionLevelTraceSetting.properties.TracingConfig).toBeUndefined();
     expect(lambdaWithOutTraceSetting.properties.TracingConfig).toBeUndefined();


### PR DESCRIPTION
### What does this PR do?

Right now, tracing is enabled globally without the ability to override on a function level, this PR aims to address that by setting the tracing config value only if the function doesn't have it defined on a local level. 

### Motivation

N/A

### Testing Guidelines

Deployed to our environment and it did what was intended which is not override tracing configs when we defined it on a function level. 

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
