### PR TITLE
Add Source Code Integration param and SAM usage instructions

### DIFF
--- a/serverless/README.md
+++ b/serverless/README.md
@@ -42,7 +42,7 @@ aws cloudformation update-stack \
 
 ## Usage with AWS SAM
 
-To deploy your serverless application with SAM, add the Datadog Serverless CloudFormation macro under the `Transform` section in your `template.yml` file, after the required SAM transform
+To deploy your serverless application with SAM, add the Datadog Serverless CloudFormation macro under the `Transform` section in your `template.yml` file, after the required SAM transform. Also add a DDGitData param and pass it to the macro to enable Datadog Source Code Integration:
 
 ```yaml
 Transform:
@@ -57,7 +57,7 @@ Transform:
       env: "<ENV>" # Optional
       version: "<VERSION>" # Optional
       tags: "<TAGS>" # Optional
-      # Pass the DDGitData param of this template to the Datadog macro here to enable Source Code integration tagging
+      # Pass DDGitData here to enable Source Code Integration tagging
       gitData: !Ref DDGitData
       # For additional parameters, see the Configuration section
 

--- a/serverless/README.md
+++ b/serverless/README.md
@@ -42,7 +42,7 @@ aws cloudformation update-stack \
 
 ## Usage with AWS SAM
 
-To deploy your serverless application with SAM, add the Datadog Serverless CloudFormation macro under the `Transform` section in your `template.yml` file, after the required SAM transform:
+To deploy your serverless application with SAM, add the Datadog Serverless CloudFormation macro under the `Transform` section in your `template.yml` file, after the required SAM transform
 
 ```yaml
 Transform:
@@ -57,7 +57,20 @@ Transform:
       env: "<ENV>" # Optional
       version: "<VERSION>" # Optional
       tags: "<TAGS>" # Optional
+      # Pass the DDGitData param of this template to the Datadog macro here to enable Source Code integration tagging
+      gitData: !Ref DDGitData
       # For additional parameters, see the Configuration section
+
+Parameters:
+  DDGitData:
+    Type: String
+    Default: ""
+    Description: "The output of $(git rev-parse HEAD),$(git config --get remote.origin.url). Used for Datadog Source Code Integration tagging"
+```
+
+To set the DDGitData parameter for Datadog's Source Code Integration, use SAM's `--parameter-overrides` option:
+```bash
+sam deploy --parameter-overrides  DDGitData="$(git rev-parse HEAD),$(git config --get remote.origin.url)"
 ```
 
 Note: If you did not modify the provided `template.yml` file when you installed the macro, then the name of the macro defined in your account will be `DatadogServerless`. If you have modified the original template, make sure the name of the transform you add here matches the `Name` property of the `AWS::CloudFormation::Macro` resource.

--- a/serverless/README.md
+++ b/serverless/README.md
@@ -68,7 +68,7 @@ Parameters:
     Description: "The output of $(git rev-parse HEAD),$(git config --get remote.origin.url). Used for Datadog Source Code Integration tagging"
 ```
 
-To set the DDGitData parameter for Datadog's Source Code Integration, use SAM's `--parameter-overrides` option:
+To set the `DDGitData` parameter for Datadog's Source Code Integration, use SAM's `--parameter-overrides` option:
 ```bash
 sam deploy --parameter-overrides  DDGitData="$(git rev-parse HEAD),$(git config --get remote.origin.url)"
 ```

--- a/serverless/README.md
+++ b/serverless/README.md
@@ -42,7 +42,7 @@ aws cloudformation update-stack \
 
 ## Usage with AWS SAM
 
-To deploy your serverless application with SAM, add the Datadog Serverless CloudFormation macro under the `Transform` section in your `template.yml` file, after the required SAM transform. Also add a DDGitData param and pass it to the macro to enable Datadog Source Code Integration:
+To deploy your serverless application with SAM, add the Datadog Serverless CloudFormation macro under the `Transform` section in your `template.yml` file, after the required SAM transform. Also add a `DDGitData` parameter and pass it to the macro to enable Datadog Source Code Integration:
 
 ```yaml
 Transform:

--- a/serverless/src/git.ts
+++ b/serverless/src/git.ts
@@ -1,0 +1,41 @@
+export const filterSensitiveInfoFromRepository = (repositoryUrl: string | undefined) => {
+  try {
+    if (!repositoryUrl) {
+      return repositoryUrl;
+    }
+    if (repositoryUrl.startsWith("git@")) {
+      return repositoryUrl;
+    }
+    const { protocol, hostname, pathname } = new URL(repositoryUrl);
+    if (!protocol || !hostname) {
+      return repositoryUrl;
+    }
+
+    return `${protocol}//${hostname}${pathname}`;
+  } catch (e) {
+    return repositoryUrl;
+  }
+};
+
+// Removes sensitive info from the given git remote url and normalizes the url prefix.
+// "git@github.com:" and "https://github.com/" prefixes will be normalized into "github.com/"
+export const filterAndFormatGithubRemote = (rawRemote: string | undefined): string | undefined => {
+  rawRemote = filterSensitiveInfoFromRepository(rawRemote);
+  if (!rawRemote) {
+    return rawRemote;
+  }
+  rawRemote = rawRemote.replace(/git@github\.com:|https:\/\/github\.com\//, "github.com/");
+
+  return rawRemote;
+};
+
+export const getGitTagsFromParam = (gitDataParam: string) => {
+  const [commitSha, rawGitConfigUrlOutput] = gitDataParam.split(",", 2);
+
+  const sanitizedRemote = filterAndFormatGithubRemote(rawGitConfigUrlOutput);
+
+  const gitCommitShaTag = `git.commit.sha:${commitSha}`;
+  const gitRepoUrlTag = `git.repository_url:${sanitizedRemote}`;
+
+  return { gitCommitShaTag, gitRepoUrlTag };
+};

--- a/serverless/src/git.ts
+++ b/serverless/src/git.ts
@@ -17,16 +17,7 @@ export const filterSensitiveInfoFromRepository = (repositoryUrl: string | undefi
   }
 };
 
-// Removes sensitive info from the given git remote url and normalizes the url prefix.
-// "git@github.com:" and "https://github.com/" prefixes will be normalized into "github.com/"
-export const filterAndFormatGithubRemote = (rawRemote: string | undefined): string | undefined => {
-  rawRemote = filterSensitiveInfoFromRepository(rawRemote);
-  if (!rawRemote) {
-    return rawRemote;
-  }
-  rawRemote = rawRemote.replace(/git@github\.com:|https:\/\/github\.com\//, "github.com/");
 
-  return rawRemote;
 /**
  * Removes sensitive information from the given git remote
  * URL and normalizes the URL prefix.
@@ -36,6 +27,23 @@ export const filterAndFormatGithubRemote = (rawRemote: string | undefined): stri
  * filterAndFormatGithubRemote("git@github.com")
  * filterAndFormatGithubRemote("https://github.com")
  * 
- * @param rawRemote git remote URL.
- * @returns 
+ * @param rawRemote git remote URL
+ * @returns normalized URL prefix
  */
+export const filterAndFormatGithubRemote = (rawRemote: string | undefined): string | undefined => {
+  rawRemote = filterSensitiveInfoFromRepository(rawRemote);
+  if (!rawRemote) {
+    return rawRemote;
+  }
+  rawRemote = rawRemote.replace(/git@github\.com:|https:\/\/github\.com\//, "github.com/");
+
+  return rawRemote;
+}
+
+export const getGitTagsFromParam = (gitDataParam: string) => {
+  const [commitSha, rawGitConfigUrlOutput] = gitDataParam.split(",", 2);
+  const sanitizedRemote = filterAndFormatGithubRemote(rawGitConfigUrlOutput);
+  const gitCommitShaTag = `git.commit.sha:${commitSha}`;
+  const gitRepoUrlTag = `git.repository_url:${sanitizedRemote}`;
+  return { gitCommitShaTag, gitRepoUrlTag };
+};

--- a/serverless/src/git.ts
+++ b/serverless/src/git.ts
@@ -17,16 +17,15 @@ export const filterSensitiveInfoFromRepository = (repositoryUrl: string | undefi
   }
 };
 
-
 /**
  * Removes sensitive information from the given git remote
  * URL and normalizes the URL prefix.
- * 
+ *
  * @example
  * // returns "github.com/"
  * filterAndFormatGithubRemote("git@github.com")
  * filterAndFormatGithubRemote("https://github.com")
- * 
+ *
  * @param rawRemote git remote URL
  * @returns normalized URL prefix
  */
@@ -38,7 +37,7 @@ export const filterAndFormatGithubRemote = (rawRemote: string | undefined): stri
   rawRemote = rawRemote.replace(/git@github\.com:|https:\/\/github\.com\//, "github.com/");
 
   return rawRemote;
-}
+};
 
 export const getGitTagsFromParam = (gitDataParam: string) => {
   const [commitSha, rawGitConfigUrlOutput] = gitDataParam.split(",", 2);

--- a/serverless/src/git.ts
+++ b/serverless/src/git.ts
@@ -27,15 +27,15 @@ export const filterAndFormatGithubRemote = (rawRemote: string | undefined): stri
   rawRemote = rawRemote.replace(/git@github\.com:|https:\/\/github\.com\//, "github.com/");
 
   return rawRemote;
-};
-
-export const getGitTagsFromParam = (gitDataParam: string) => {
-  const [commitSha, rawGitConfigUrlOutput] = gitDataParam.split(",", 2);
-
-  const sanitizedRemote = filterAndFormatGithubRemote(rawGitConfigUrlOutput);
-
-  const gitCommitShaTag = `git.commit.sha:${commitSha}`;
-  const gitRepoUrlTag = `git.repository_url:${sanitizedRemote}`;
-
-  return { gitCommitShaTag, gitRepoUrlTag };
-};
+/**
+ * Removes sensitive information from the given git remote
+ * URL and normalizes the URL prefix.
+ * 
+ * @example
+ * // returns "github.com/"
+ * filterAndFormatGithubRemote("git@github.com")
+ * filterAndFormatGithubRemote("https://github.com")
+ * 
+ * @param rawRemote git remote URL.
+ * @returns 
+ */

--- a/serverless/test/git.spec.ts
+++ b/serverless/test/git.spec.ts
@@ -1,0 +1,20 @@
+import { getGitTagsFromParam } from "../src/git";
+
+describe("getGitTagsFromParam", () => {
+  it("produces the expected tags from the param input", () => {
+    expect(getGitTagsFromParam("abcd1234,git@github.com:DataDog/datadog-cloudformation-macro.git")).toEqual({
+      gitCommitShaTag: "git.commit.sha:abcd1234",
+      gitRepoUrlTag: "git.repository_url:github.com/DataDog/datadog-cloudformation-macro.git",
+    });
+
+    expect(getGitTagsFromParam("abcd1234,https://github.com/datadog/test.git")).toEqual({
+      gitCommitShaTag: "git.commit.sha:abcd1234",
+      gitRepoUrlTag: "git.repository_url:github.com/datadog/test.git",
+    });
+
+    expect(getGitTagsFromParam("abcd1234,github.com/datadog/test.git")).toEqual({
+      gitCommitShaTag: "git.commit.sha:abcd1234",
+      gitRepoUrlTag: "git.repository_url:github.com/datadog/test.git",
+    });
+  });
+});

--- a/serverless/test/git.spec.ts
+++ b/serverless/test/git.spec.ts
@@ -1,20 +1,60 @@
-import { getGitTagsFromParam } from "../src/git";
+import { filterSensitiveInfoFromRepository, getGitTagsFromParam } from "../src/git";
 
 describe("getGitTagsFromParam", () => {
-  it("produces the expected tags from the param input", () => {
+  it("produces SCI tags with username@domain", () => {
     expect(getGitTagsFromParam("abcd1234,git@github.com:DataDog/datadog-cloudformation-macro.git")).toEqual({
       gitCommitShaTag: "git.commit.sha:abcd1234",
       gitRepoUrlTag: "git.repository_url:github.com/DataDog/datadog-cloudformation-macro.git",
     });
+  });
 
+  it("produces SCI tags with protocol", () => {
     expect(getGitTagsFromParam("abcd1234,https://github.com/datadog/test.git")).toEqual({
       gitCommitShaTag: "git.commit.sha:abcd1234",
       gitRepoUrlTag: "git.repository_url:github.com/datadog/test.git",
     });
+  });
 
+  it("produces SCI tags without protocol", () => {
     expect(getGitTagsFromParam("abcd1234,github.com/datadog/test.git")).toEqual({
       gitCommitShaTag: "git.commit.sha:abcd1234",
       gitRepoUrlTag: "git.repository_url:github.com/datadog/test.git",
     });
+  });
+});
+
+describe("filterSensitiveInfoFromRepository", () => {
+  it("returns undefined when URL input is undefined", () => {
+    expect(filterSensitiveInfoFromRepository(undefined)).toBeUndefined();
+  });
+
+  it("returns original URL when starts with git@", () => {
+    expect(filterSensitiveInfoFromRepository("git@github.com:username/repo.git")).toBe(
+      "git@github.com:username/repo.git",
+    );
+  });
+
+  it("returns original URL when not a valid URL", () => {
+    expect(filterSensitiveInfoFromRepository("not-a-valid-url")).toBe("not-a-valid-url");
+  });
+
+  it("removes sensitive info from valid HTTP URL", () => {
+    expect(filterSensitiveInfoFromRepository("http://user:pass@github.com/path/to/repo.git")).toBe(
+      "http://github.com/path/to/repo.git",
+    );
+  });
+
+  it("removes sensitive info from valid HTTPS URL", () => {
+    expect(filterSensitiveInfoFromRepository("https://user:pass@github.com/path/to/repo.git")).toBe(
+      "https://github.com/path/to/repo.git",
+    );
+  });
+
+  it("returns original URL when protocol or hostname is missing", () => {
+    expect(filterSensitiveInfoFromRepository("/path/to/repo.git")).toBe("/path/to/repo.git");
+  });
+
+  it("handles exception and returns original URL when invalid URL is passed", () => {
+    expect(filterSensitiveInfoFromRepository("http://github.com:demo")).toBe("http://github.com:demo");
   });
 });


### PR DESCRIPTION
### What does this PR do?
Adds a param to the macro that can be used with SAM's --parameter-overrides option and local git commands to automatically add the `git.commit.sha` and `git.repository_url` tags used by Datadog Source Code Integration. 

### Motivation
Easy set up and usage of SCI

### Testing Guidelines
Deployed with a sample SAM app with and without setting the param. 

### Additional Notes


### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [x] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [x] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
