### PR TITLE
Read config from ENV vars

### DIFF
--- a/serverless/README.md
+++ b/serverless/README.md
@@ -62,6 +62,28 @@ Transform:
 
 Note: If you did not modify the provided `template.yml` file when you installed the macro, then the name of the macro defined in your account will be `DatadogServerless`. If you have modified the original template, make sure the name of the transform you add here matches the `Name` property of the `AWS::CloudFormation::Macro` resource.
 
+Note: If you want to specify some of the configuration only once, you may modify `template.yml` and add the environment variables you want to configure for that region. Think of this as a way to control additional default values. The example below sets `DD_API_KEY_SECRET_ARN` and `DD_ENV`, which the macro will treat as default values:
+
+```yaml
+Resources:
+  MacroFunction:
+    Type: AWS::Serverless::Function
+    DependsOn: MacroFunctionZip
+    Properties:
+      FunctionName:
+        Fn::If:
+          - SetFunctionName
+          - Ref: FunctionName
+          - Ref: AWS::NoValue
+      Description: Processes a CloudFormation template to install Datadog Lambda layers for Python and Node.js Lambda functions.
+      Handler: src/index.handler
+      ...
+      Environment:
+        Variables:
+          DD_API_KEY_SECRET_ARN: "arn:aws:secretsmanager:us-west-2:123456789012:secret:DdApiKeySecret-e1v5Yn7TvIPc-d1Qc4E"
+          DD_ENV: "dev"
+```
+
 ## Configuration
 
 To further configure your plugin, use the following custom parameters:

--- a/serverless/README.md
+++ b/serverless/README.md
@@ -62,7 +62,7 @@ Transform:
 
 Note: If you did not modify the provided `template.yml` file when you installed the macro, then the name of the macro defined in your account will be `DatadogServerless`. If you have modified the original template, make sure the name of the transform you add here matches the `Name` property of the `AWS::CloudFormation::Macro` resource.
 
-Note: If you want to specify some of the configuration only once, you may modify `template.yml` and add the environment variables you want to configure for that region. Think of this as a way to control additional default values. The example below sets `DD_API_KEY_SECRET_ARN` and `DD_ENV`, which the macro will treat as default values:
+Note: If you want to specify some of the configuration only once, you can modify `template.yml` and add the environment variables you want to configure for that region. This is a way to control additional default values. The example below sets `DD_API_KEY_SECRET_ARN` and `DD_ENV`, which the macro will treats as default values:
 
 ```yaml
 Resources:

--- a/serverless/src/env.ts
+++ b/serverless/src/env.ts
@@ -112,6 +112,38 @@ export const defaultConfiguration: Configuration = {
 };
 
 /**
+ * Returns the default configuration with any values overwritten by environment variables.
+ */
+export function getConfigFromEnvVars(): Configuration {
+  const config: Configuration = {
+    ...defaultConfiguration,
+  };
+
+  apiKeyEnvVar in process.env ? (config.apiKey = process.env[apiKeyEnvVar]) : null;
+  apiKeySecretArnEnvVar in process.env ? (config.apiKeySecretArn = process.env[apiKeySecretArnEnvVar]) : null;
+  apiKeyKMSEnvVar in process.env ? (config.apiKMSKey = process.env[apiKeyKMSEnvVar]) : null;
+  siteURLEnvVar in process.env ? (config.site = process.env[siteURLEnvVar] || defaultConfiguration.site) : null;
+  logLevelEnvVar in process.env ? (config.logLevel = process.env[logLevelEnvVar]) : null;
+  logForwardingEnvVar in process.env ? (config.flushMetricsToLogs = process.env[logForwardingEnvVar] === "true") : null;
+  enhancedMetricsEnvVar in process.env ? (config.enableEnhancedMetrics = process.env[enhancedMetricsEnvVar] === "true") : null;
+  enableDDLogsEnvVar in process.env ? (config.enableDDLogs = process.env[enableDDLogsEnvVar] === "true") : null;
+  captureLambdaPayloadEnvVar in process.env ? (config.captureLambdaPayload = process.env[captureLambdaPayloadEnvVar] === "true") : null;
+  serviceEnvVar in process.env ? (config.service = process.env[serviceEnvVar]) : null;
+  envEnvVar in process.env ? (config.env = process.env[envEnvVar]) : null;
+  versionEnvVar in process.env ? (config.version = process.env[versionEnvVar]) : null;
+  tagsEnvVar in process.env ? (config.tags = process.env[tagsEnvVar]) : null;
+  ddColdStartTracingEnabledEnvVar in process.env ? (config.enableColdStartTracing = process.env[ddColdStartTracingEnabledEnvVar] === "true") : null;
+  ddMinColdStartDurationEnvVar in process.env ? (config.minColdStartTraceDuration = process.env[ddMinColdStartDurationEnvVar]) : null;
+  ddColdStartTracingSkipLibsEnvVar in process.env ? (config.coldStartTraceSkipLibs = process.env[ddColdStartTracingSkipLibsEnvVar]) : null;
+  ddProfilingEnabledEnvVar in process.env ? (config.enableProfiling = process.env[ddProfilingEnabledEnvVar] === "true") : null;
+  ddEncodeAuthorizerContextEnvVar in process.env ? (config.encodeAuthorizerContext = process.env[ddEncodeAuthorizerContextEnvVar] === "true") : null;
+  ddDecodeAuthorizerContextEnvVar in process.env ? (config.decodeAuthorizerContext = process.env[ddDecodeAuthorizerContextEnvVar] === "true") : null;
+  ddApmFlushDeadlineMillisecondsEnvVar in process.env ? (config.apmFlushDeadline = process.env[ddApmFlushDeadlineMillisecondsEnvVar]) : null;
+
+  return config;
+}
+
+/**
  * Parses the Mappings section for Datadog config parameters.
  * Assumes that the parameters live under the Mappings section in this format:
  *
@@ -124,7 +156,7 @@ export const defaultConfiguration: Configuration = {
 export function getConfigFromCfnMappings(mappings: any): Configuration {
   if (mappings === undefined || mappings[DATADOG] === undefined) {
     log.debug("No Datadog mappings found in the CloudFormation template, using the default config");
-    return defaultConfiguration;
+    return getConfigFromEnvVars();
   }
   return getConfigFromCfnParams(mappings[DATADOG][PARAMETERS]);
 }
@@ -145,7 +177,7 @@ export function getConfigFromCfnParams(params: CfnParams) {
     datadogConfig = {};
   }
   return {
-    ...defaultConfiguration,
+    ...getConfigFromEnvVars(),
     ...datadogConfig,
   };
 }

--- a/serverless/src/env.ts
+++ b/serverless/src/env.ts
@@ -129,7 +129,8 @@ export function getConfigFromEnvVars(): Configuration {
     config.apiKMSKey = process.env[apiKeyKMSEnvVar];
   }
   if (siteURLEnvVar in process.env && process.env[siteURLEnvVar] !== undefined) {
-    config.site = process.env[siteURLEnvVar];
+    // Fall back to default site for type safety
+    config.site = process.env[siteURLEnvVar] ?? defaultConfiguration.site;
   }
   if (logLevelEnvVar in process.env) {
     config.logLevel = process.env[logLevelEnvVar];

--- a/serverless/src/env.ts
+++ b/serverless/src/env.ts
@@ -119,26 +119,66 @@ export function getConfigFromEnvVars(): Configuration {
     ...defaultConfiguration,
   };
 
-  apiKeyEnvVar in process.env ? (config.apiKey = process.env[apiKeyEnvVar]) : null;
-  apiKeySecretArnEnvVar in process.env ? (config.apiKeySecretArn = process.env[apiKeySecretArnEnvVar]) : null;
-  apiKeyKMSEnvVar in process.env ? (config.apiKMSKey = process.env[apiKeyKMSEnvVar]) : null;
-  siteURLEnvVar in process.env ? (config.site = process.env[siteURLEnvVar] || defaultConfiguration.site) : null;
-  logLevelEnvVar in process.env ? (config.logLevel = process.env[logLevelEnvVar]) : null;
-  logForwardingEnvVar in process.env ? (config.flushMetricsToLogs = process.env[logForwardingEnvVar] === "true") : null;
-  enhancedMetricsEnvVar in process.env ? (config.enableEnhancedMetrics = process.env[enhancedMetricsEnvVar] === "true") : null;
-  enableDDLogsEnvVar in process.env ? (config.enableDDLogs = process.env[enableDDLogsEnvVar] === "true") : null;
-  captureLambdaPayloadEnvVar in process.env ? (config.captureLambdaPayload = process.env[captureLambdaPayloadEnvVar] === "true") : null;
-  serviceEnvVar in process.env ? (config.service = process.env[serviceEnvVar]) : null;
-  envEnvVar in process.env ? (config.env = process.env[envEnvVar]) : null;
-  versionEnvVar in process.env ? (config.version = process.env[versionEnvVar]) : null;
-  tagsEnvVar in process.env ? (config.tags = process.env[tagsEnvVar]) : null;
-  ddColdStartTracingEnabledEnvVar in process.env ? (config.enableColdStartTracing = process.env[ddColdStartTracingEnabledEnvVar] === "true") : null;
-  ddMinColdStartDurationEnvVar in process.env ? (config.minColdStartTraceDuration = process.env[ddMinColdStartDurationEnvVar]) : null;
-  ddColdStartTracingSkipLibsEnvVar in process.env ? (config.coldStartTraceSkipLibs = process.env[ddColdStartTracingSkipLibsEnvVar]) : null;
-  ddProfilingEnabledEnvVar in process.env ? (config.enableProfiling = process.env[ddProfilingEnabledEnvVar] === "true") : null;
-  ddEncodeAuthorizerContextEnvVar in process.env ? (config.encodeAuthorizerContext = process.env[ddEncodeAuthorizerContextEnvVar] === "true") : null;
-  ddDecodeAuthorizerContextEnvVar in process.env ? (config.decodeAuthorizerContext = process.env[ddDecodeAuthorizerContextEnvVar] === "true") : null;
-  ddApmFlushDeadlineMillisecondsEnvVar in process.env ? (config.apmFlushDeadline = process.env[ddApmFlushDeadlineMillisecondsEnvVar]) : null;
+  if (apiKeyEnvVar in process.env) {
+    config.apiKey = process.env[apiKeyEnvVar];
+  }
+  if (apiKeySecretArnEnvVar in process.env) {
+    config.apiKeySecretArn = process.env[apiKeySecretArnEnvVar];
+  }
+  if (apiKeyKMSEnvVar in process.env) {
+    config.apiKMSKey = process.env[apiKeyKMSEnvVar];
+  }
+  if (siteURLEnvVar in process.env && process.env[siteURLEnvVar] !== undefined) {
+    config.site = process.env[siteURLEnvVar];
+  }
+  if (logLevelEnvVar in process.env) {
+    config.logLevel = process.env[logLevelEnvVar];
+  }
+  if (logForwardingEnvVar in process.env) {
+    config.flushMetricsToLogs = process.env[logForwardingEnvVar] === "true";
+  }
+  if (enhancedMetricsEnvVar in process.env) {
+    config.enableEnhancedMetrics = process.env[enhancedMetricsEnvVar] === "true";
+  }
+  if (enableDDLogsEnvVar in process.env) {
+    config.enableDDLogs = process.env[enableDDLogsEnvVar] === "true";
+  }
+  if (captureLambdaPayloadEnvVar in process.env) {
+    config.captureLambdaPayload = process.env[captureLambdaPayloadEnvVar] === "true";
+  }
+  if (serviceEnvVar in process.env) {
+    config.service = process.env[serviceEnvVar];
+  }
+  if (envEnvVar in process.env) {
+    config.env = process.env[envEnvVar];
+  }
+  if (versionEnvVar in process.env) {
+    config.version = process.env[versionEnvVar];
+  }
+  if (tagsEnvVar in process.env) {
+    config.tags = process.env[tagsEnvVar];
+  }
+  if (ddColdStartTracingEnabledEnvVar in process.env) {
+    config.enableColdStartTracing = process.env[ddColdStartTracingEnabledEnvVar] === "true";
+  }
+  if (ddMinColdStartDurationEnvVar in process.env) {
+    config.minColdStartTraceDuration = process.env[ddMinColdStartDurationEnvVar];
+  }
+  if (ddColdStartTracingSkipLibsEnvVar in process.env) {
+    config.coldStartTraceSkipLibs = process.env[ddColdStartTracingSkipLibsEnvVar];
+  }
+  if (ddProfilingEnabledEnvVar in process.env) {
+    config.enableProfiling = process.env[ddProfilingEnabledEnvVar] === "true";
+  }
+  if (ddEncodeAuthorizerContextEnvVar in process.env) {
+    config.encodeAuthorizerContext = process.env[ddEncodeAuthorizerContextEnvVar] === "true";
+  }
+  if (ddDecodeAuthorizerContextEnvVar in process.env) {
+    config.decodeAuthorizerContext = process.env[ddDecodeAuthorizerContextEnvVar] === "true";
+  }
+  if (ddApmFlushDeadlineMillisecondsEnvVar in process.env) {
+    config.apmFlushDeadline = process.env[ddApmFlushDeadlineMillisecondsEnvVar];
+  }
 
   return config;
 }

--- a/serverless/src/index.ts
+++ b/serverless/src/index.ts
@@ -79,6 +79,7 @@ export const handler = async (event: InputEvent, _: any) => {
       };
     }
 
+    //
     const lambdas = findLambdas(resources, event.templateParameterValues);
     log.debug(`Lambda resources found: ${JSON.stringify(lambdas)}`);
 

--- a/serverless/test/env.spec.ts
+++ b/serverless/test/env.spec.ts
@@ -47,7 +47,7 @@ describe("getConfig", () => {
     const CURRENT_ENV = process.env;
 
     beforeEach(() => {
-      jest.resetModules() // Clear the cache
+      jest.resetModules(); // Clear the cache
       process.env = { ...CURRENT_ENV }; // Make a copy we can modify
     });
 
@@ -56,8 +56,9 @@ describe("getConfig", () => {
     });
 
     it("gets default values overwritten by environment variables", () => {
-      process.env['DD_API_KEY_SECRET_ARN'] = 'arn:aws:secretsmanager:my-region-1:123456789012:secret:DdApiKeySecret-abcd1234'
-      process.env['DD_FLUSH_TO_LOG'] = 'false'
+      process.env["DD_API_KEY_SECRET_ARN"] =
+        "arn:aws:secretsmanager:my-region-1:123456789012:secret:DdApiKeySecret-abcd1234";
+      process.env["DD_FLUSH_TO_LOG"] = "false";
       const config = getConfigFromEnvVars();
       expect(config).toEqual({
         addLayers: true,
@@ -69,15 +70,16 @@ describe("getConfig", () => {
         enableDDLogs: true,
         enableEnhancedMetrics: true,
         captureLambdaPayload: false,
-        apiKeySecretArn: 'arn:aws:secretsmanager:my-region-1:123456789012:secret:DdApiKeySecret-abcd1234',
+        apiKeySecretArn: "arn:aws:secretsmanager:my-region-1:123456789012:secret:DdApiKeySecret-abcd1234",
       });
     });
 
     it("gets a mixed a configuration when some values are present", () => {
-      process.env['DD_API_KEY_SECRET_ARN'] = 'arn:aws:secretsmanager:my-region-1:123456789012:secret:DdApiKeySecret-abcd1234'
-      process.env['DD_FLUSH_TO_LOG'] = 'false'
-      process.env['DD_ENHANCED_METRICS'] = 'false'
-      process.env['DD_CAPTURE_LAMBDA_PAYLOAD'] = 'true'
+      process.env["DD_API_KEY_SECRET_ARN"] =
+        "arn:aws:secretsmanager:my-region-1:123456789012:secret:DdApiKeySecret-abcd1234";
+      process.env["DD_FLUSH_TO_LOG"] = "false";
+      process.env["DD_ENHANCED_METRICS"] = "false";
+      process.env["DD_CAPTURE_LAMBDA_PAYLOAD"] = "true";
       const params = {
         site: "my-site",
         enableXrayTracing: false,
@@ -94,10 +96,9 @@ describe("getConfig", () => {
         enableDDLogs: true,
         enableEnhancedMetrics: true,
         captureLambdaPayload: false,
-        apiKeySecretArn: 'arn:aws:secretsmanager:my-region-1:123456789012:secret:DdApiKeySecret-abcd1234',
+        apiKeySecretArn: "arn:aws:secretsmanager:my-region-1:123456789012:secret:DdApiKeySecret-abcd1234",
       });
     });
-
   });
 });
 

--- a/serverless/test/env.spec.ts
+++ b/serverless/test/env.spec.ts
@@ -1,4 +1,5 @@
 import {
+  getConfigFromEnvVars,
   getConfigFromCfnMappings,
   getConfigFromCfnParams,
   defaultConfiguration,
@@ -40,6 +41,63 @@ describe("getConfig", () => {
       enableEnhancedMetrics: true,
       captureLambdaPayload: false,
     });
+  });
+
+  describe("with env vars set", () => {
+    const CURRENT_ENV = process.env;
+
+    beforeEach(() => {
+      jest.resetModules() // Clear the cache
+      process.env = { ...CURRENT_ENV }; // Make a copy we can modify
+    });
+
+    afterEach(() => {
+      process.env = CURRENT_ENV; // Restore environment
+    });
+
+    it("gets default values overwritten by environment variables", () => {
+      process.env['DD_API_KEY_SECRET_ARN'] = 'arn:aws:secretsmanager:my-region-1:123456789012:secret:DdApiKeySecret-abcd1234'
+      process.env['DD_FLUSH_TO_LOG'] = 'false'
+      const config = getConfigFromEnvVars();
+      expect(config).toEqual({
+        addLayers: true,
+        flushMetricsToLogs: false,
+        logLevel: undefined,
+        site: "datadoghq.com",
+        enableXrayTracing: false,
+        enableDDTracing: true,
+        enableDDLogs: true,
+        enableEnhancedMetrics: true,
+        captureLambdaPayload: false,
+        apiKeySecretArn: 'arn:aws:secretsmanager:my-region-1:123456789012:secret:DdApiKeySecret-abcd1234',
+      });
+    });
+
+    it("gets a mixed a configuration when some values are present", () => {
+      process.env['DD_API_KEY_SECRET_ARN'] = 'arn:aws:secretsmanager:my-region-1:123456789012:secret:DdApiKeySecret-abcd1234'
+      process.env['DD_FLUSH_TO_LOG'] = 'false'
+      process.env['DD_ENHANCED_METRICS'] = 'false'
+      process.env['DD_CAPTURE_LAMBDA_PAYLOAD'] = 'true'
+      const params = {
+        site: "my-site",
+        enableXrayTracing: false,
+        enableEnhancedMetrics: true,
+        captureLambdaPayload: false,
+      };
+      const config = getConfigFromCfnParams(params);
+      expect(config).toEqual({
+        addLayers: true,
+        flushMetricsToLogs: false,
+        site: "my-site",
+        enableXrayTracing: false,
+        enableDDTracing: true,
+        enableDDLogs: true,
+        enableEnhancedMetrics: true,
+        captureLambdaPayload: false,
+        apiKeySecretArn: 'arn:aws:secretsmanager:my-region-1:123456789012:secret:DdApiKeySecret-abcd1234',
+      });
+    });
+
   });
 });
 

--- a/serverless/test/tags.spec.ts
+++ b/serverless/test/tags.spec.ts
@@ -48,7 +48,7 @@ describe("addDDTags", () => {
     const CURRENT_ENV = process.env;
 
     beforeEach(() => {
-      jest.resetModules() // Clear the cache
+      jest.resetModules(); // Clear the cache
       process.env = { ...CURRENT_ENV }; // Make a copy we can modify
     });
 
@@ -57,7 +57,7 @@ describe("addDDTags", () => {
     });
 
     it("does add tags from the environment", () => {
-      process.env['DD_TAGS'] = 'strongest_avenger:hulk'
+      process.env["DD_TAGS"] = "strongest_avenger:hulk";
       const config = {
         ...getConfigFromEnvVars(),
         service: "my-service",


### PR DESCRIPTION
### What does this PR do?

As discussed in #88, this adds the ability to specify configuration via environment variables on the Macro Lambda function.

Resolves #88

### Motivation

I wanted to simplify all of my SAM templates and not have each one specify the ARN of the Datadog secret, when it is the same in every region the Macro function is deployed.

### Testing Guidelines

The automated tests ensure the order of precedence for configuration is:
1. Default values
2. Environment variables specified on the Macro Lambda function
3. Mappings section or Parameters
... which allows the maximum flexibility.

### Additional Notes

One difference from the proposal in #88 is that I didn't have to modify any validation logic. I did this only by modifying the order in which configuration default values are read.

To be sure I didn't break anything in the tags code, I also added a test for that too.

### Types of changes

- [X] New feature

### Check all that apply

- [X] This PR's description is comprehensive
- [X] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [X] This PR's changes are covered by the automated tests
