### PR TITLE
Handle conditionals in Layers definition

### DIFF
--- a/serverless/src/index.ts
+++ b/serverless/src/index.ts
@@ -11,6 +11,8 @@ import log from "loglevel";
 const SUCCESS = "success";
 const FAILURE = "failure";
 
+export const CFN_IF_FUNCTION_STRING = "Fn::If";
+
 export type Parameters = { [key: string]: any };
 
 export interface Resources {
@@ -24,6 +26,10 @@ interface CfnTemplate {
   Mappings?: any;
   Resources: Resources;
 }
+
+export type LambdaLayersProperty =
+  | string[]
+  | { [CFN_IF_FUNCTION_STRING]: [string, LambdaLayersProperty, LambdaLayersProperty] };
 
 export interface InputEvent {
   region: string;
@@ -42,7 +48,7 @@ export interface FunctionProperties {
   Code: any;
   Environment?: { Variables?: { [key: string]: string | boolean } };
   Tags?: { Key: string; Value: string }[];
-  Layers?: string[];
+  Layers?: LambdaLayersProperty;
   TracingConfig?: { [key: string]: string };
   FunctionName?: string;
   Architectures?: [string];

--- a/serverless/src/index.ts
+++ b/serverless/src/index.ts
@@ -27,8 +27,11 @@ interface CfnTemplate {
   Resources: Resources;
 }
 
+// Array of string ARNs in normal case. Can also include
+// CFN conditional objects represented as e.g.:
+// {"Fn::If": ["isProd", ["prod-layer-arn"], ["stg-layer-arn"]]}
 export type LambdaLayersProperty =
-  | string[]
+  | (string | LambdaLayersProperty)[]
   | { [CFN_IF_FUNCTION_STRING]: [string, LambdaLayersProperty, LambdaLayersProperty] };
 
 export interface InputEvent {


### PR DESCRIPTION
### What does this PR do?
Fixes a bug where the macro would get an error when the Layers definition was not an array, e.g. when it's a CFN conditional. This PR updates the code to handle this situation and add the expected layers to all possible outputs of the conditional

### Motivation
Bug

### Testing Guidelines
* Added unit tests
* Tested deploying a function with a conditional statement in its Layers definition

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
