### PR TITLE
Fix env vars when macro is used without extensionLayerVersion set

### DIFF
--- a/serverless/src/env.ts
+++ b/serverless/src/env.ts
@@ -321,30 +321,33 @@ export function setEnvConfiguration(config: Configuration, lambdas: LambdaFuncti
       envVariables[captureLambdaPayloadEnvVar] = config.captureLambdaPayload;
     }
 
-    if (config.extensionLayerVersion) {
-      if (config.service !== undefined && envVariables[serviceEnvVar] === undefined) {
-        envVariables[serviceEnvVar] = config.service;
-      }
-      if (config.env !== undefined && envVariables[envEnvVar] === undefined) {
-        envVariables[envEnvVar] = config.env;
-      }
-      if (config.version !== undefined && envVariables[versionEnvVar] === undefined) {
-        envVariables[versionEnvVar] = config.version;
-      }
-      if (config.tags !== undefined && envVariables[tagsEnvVar] === undefined) {
-        envVariables[tagsEnvVar] = config.tags;
-      }
-      if (config.gitData !== undefined) {
-        const { gitCommitShaTag, gitRepoUrlTag } = getGitTagsFromParam(config.gitData);
-        const gitTagString = `${gitCommitShaTag},${gitRepoUrlTag}`;
+    if (config.service !== undefined && envVariables[serviceEnvVar] === undefined) {
+      envVariables[serviceEnvVar] = config.service;
+    }
 
-        if (envVariables[tagsEnvVar] !== undefined) {
-          envVariables[tagsEnvVar] = `${envVariables[tagsEnvVar]},${gitTagString}`;
-        } else {
-          envVariables[tagsEnvVar] = gitTagString;
-        }
+    if (config.env !== undefined && envVariables[envEnvVar] === undefined) {
+      envVariables[envEnvVar] = config.env;
+    }
+
+    if (config.extensionLayerVersion && config.version !== undefined && envVariables[versionEnvVar] === undefined) {
+      envVariables[versionEnvVar] = config.version;
+    }
+
+    if (config.tags !== undefined && envVariables[tagsEnvVar] === undefined) {
+      envVariables[tagsEnvVar] = config.tags;
+    }
+
+    if (config.gitData !== undefined) {
+      const { gitCommitShaTag, gitRepoUrlTag } = getGitTagsFromParam(config.gitData);
+      const gitTagString = `${gitCommitShaTag},${gitRepoUrlTag}`;
+
+      if (envVariables[tagsEnvVar] !== undefined) {
+        envVariables[tagsEnvVar] = `${envVariables[tagsEnvVar]},${gitTagString}`;
+      } else {
+        envVariables[tagsEnvVar] = gitTagString;
       }
     }
+
     if (config.enableColdStartTracing !== undefined && envVariables[ddColdStartTracingEnabledEnvVar] === undefined) {
       envVariables[ddColdStartTracingEnabledEnvVar] = config.enableColdStartTracing;
     }

--- a/serverless/test/env.spec.ts
+++ b/serverless/test/env.spec.ts
@@ -103,7 +103,87 @@ describe("getConfig", () => {
 });
 
 describe("setEnvConfiguration", () => {
-  it("sets env vars (with extension)", () => {
+  it("sets env vars with simple config and extension", () => {
+    const lambda: LambdaFunction = {
+      properties: {
+        Handler: "app.handler",
+        Runtime: "python2.7",
+        Role: "role-arn",
+        Code: {},
+      },
+      key: "FunctionKey",
+      runtimeType: RuntimeType.PYTHON,
+      runtime: "python2.7",
+      architecture: "x86_64",
+      architectureType: ArchitectureType.x86_64,
+    };
+    const config = {
+      addLayers: false,
+      apiKey: "1234",
+      extensionLayerVersion: 13,
+      service: "my-service",
+      env: "test",
+      version: "1",
+      tags: "team:avengers,project:marvel",
+    };
+    setEnvConfiguration({ ...defaultConfiguration, ...config }, [lambda]);
+
+    expect(lambda.properties.Environment).toEqual({
+      Variables: {
+        DD_API_KEY: "1234",
+        DD_CAPTURE_LAMBDA_PAYLOAD: false,
+        DD_ENHANCED_METRICS: true,
+        DD_FLUSH_TO_LOG: true,
+        DD_SITE: "datadoghq.com",
+        DD_ENV: "test",
+        DD_SERVICE: "my-service",
+        DD_VERSION: "1",
+        DD_TAGS: "team:avengers,project:marvel",
+        DD_SERVERLESS_LOGS_ENABLED: true,
+      },
+    });
+  });
+
+  it("sets env vars with simple config without extension", () => {
+    const lambda: LambdaFunction = {
+      properties: {
+        Handler: "app.handler",
+        Runtime: "python2.7",
+        Role: "role-arn",
+        Code: {},
+      },
+      key: "FunctionKey",
+      runtimeType: RuntimeType.PYTHON,
+      runtime: "python2.7",
+      architecture: "x86_64",
+      architectureType: ArchitectureType.x86_64,
+    };
+    const config = {
+      addLayers: false,
+      apiKey: "1234",
+      service: "my-service",
+      env: "test",
+      version: "1",
+      tags: "team:avengers,project:marvel",
+    };
+    setEnvConfiguration({ ...defaultConfiguration, ...config }, [lambda]);
+
+    expect(lambda.properties.Environment).toEqual({
+      Variables: {
+        DD_API_KEY: "1234",
+        DD_CAPTURE_LAMBDA_PAYLOAD: false,
+        DD_ENHANCED_METRICS: true,
+        DD_FLUSH_TO_LOG: true,
+        DD_SITE: "datadoghq.com",
+        DD_ENV: "test",
+        DD_SERVICE: "my-service",
+        DD_TAGS: "team:avengers,project:marvel",
+        DD_SERVERLESS_LOGS_ENABLED: true,
+      },
+    });
+  });
+
+  it("sets env vars with complicated config and extension)", () => {
     const lambda: LambdaFunction = {
       properties: {
         Handler: "app.handler",
@@ -169,7 +249,7 @@ describe("setEnvConfiguration", () => {
     });
   });
 
-  it("sets env vars (without extension)", () => {
+  it("sets env vars with complicated config without extension", () => {
     const lambda: LambdaFunction = {
       properties: {
         Handler: "app.handler",
@@ -218,7 +298,9 @@ describe("setEnvConfiguration", () => {
         DD_LOG_LEVEL: "debug",
         DD_SITE: "datadoghq.eu",
         DD_ENHANCED_METRICS: true,
+        DD_ENV: "test",
         DD_SERVERLESS_LOGS_ENABLED: true,
+        DD_SERVICE: "my-service",
         DD_CAPTURE_LAMBDA_PAYLOAD: true,
         DD_COLD_START_TRACING: true,
         DD_MIN_COLD_START_DURATION: "80",
@@ -226,6 +308,7 @@ describe("setEnvConfiguration", () => {
         DD_PROFILING_ENABLED: true,
         DD_ENCODE_AUTHORIZER_CONTEXT: true,
         DD_DECODE_AUTHORIZER_CONTEXT: true,
+        DD_TAGS: "team:avengers,project:marvel",
       },
     });
   });


### PR DESCRIPTION
### What does this PR do?
* Fixes a bug where not all env vars would be set if the macro is used without the extension
* Fixes existing tests
* Adds unit tests

### Motivation
https://github.com/DataDog/datadog-cloudformation-macro/issues/92 thanks to @cscetbon

### Testing Guidelines
* Added unit tests
* Tested with an example stack

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
