### PR TITLE
Increases timeout for layer implementation

### DIFF
--- a/serverless/template.yml
+++ b/serverless/template.yml
@@ -56,6 +56,7 @@ Resources:
           - Ref: FunctionName
           - Ref: AWS::NoValue
       Description: Processes a CloudFormation template to install Datadog Lambda layers for Python and Node.js Lambda functions.
+      Timeout: 10
       Handler: src/index.handler
       Runtime: nodejs16.x
       CodeUri:


### PR DESCRIPTION
### What does this PR do?

This increases the timeout necessary for the MacroFunction to process installing the Datadog Lambda layer to instrument Lambda functions.  

### Motivation

Default looks like it was 3 seconds and triggering a timeout and rollback which prevented deployment of our Stack.  

### Testing Guidelines

Manual regression

### Additional Notes

Related to issue with support team #1310259

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [x] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
