### PR TITLE
Add arch invalid error

### DIFF
--- a/serverless/src/layer.ts
+++ b/serverless/src/layer.ts
@@ -182,6 +182,11 @@ export function applyLayers(
 
     if (extensionLayerVersion !== undefined) {
       log.debug(`Setting Lambda Extension layer for ${lambda.key}`);
+      // ensure the extension layer is defined
+      if (architectureToExtensionLayerName[architecture] === undefined) {
+        errors.push(getMissingRuntimeLayerErrorMsg(architecture));
+        return;
+      }
       lambdaExtensionLayerArn = getExtensionLayerArn(region, extensionLayerVersion, lambda.architecture);
       addLayer(lambdaExtensionLayerArn, lambda);
     }
@@ -247,11 +252,7 @@ export function getExtensionLayerArn(region: string, version: number, architectu
   const layerName = architectureToExtensionLayerName[architecture];
 
   const isGovCloud = region === "us-gov-east-1" || region === "us-gov-west-1";
-  // ensure the extension layer is defined
-   if (layerName === undefined) {
-        errors.push(getMissingRuntimeLayerErrorMsg(architecture));
-        return;
-   }
+
   // if this is a GovCloud region, use the GovCloud lambda layer
   if (isGovCloud) {
     log.debug("GovCloud region detected, using GovCloud Lambda layer");

--- a/serverless/src/layer.ts
+++ b/serverless/src/layer.ts
@@ -247,13 +247,24 @@ export function getExtensionLayerArn(region: string, version: number, architectu
   const layerName = architectureToExtensionLayerName[architecture];
 
   const isGovCloud = region === "us-gov-east-1" || region === "us-gov-west-1";
-
+  // ensure the extension layer is defined
+   if (layerName === undefined) {
+        errors.push(getMissingRuntimeLayerErrorMsg(architecture));
+        return;
+   }
   // if this is a GovCloud region, use the GovCloud lambda layer
   if (isGovCloud) {
     log.debug("GovCloud region detected, using GovCloud Lambda layer");
     return `arn:aws-us-gov:lambda:${region}:${DD_GOV_ACCOUNT_ID}:layer:${layerName}:${version}`;
   }
   return `arn:aws:lambda:${region}:${DD_ACCOUNT_ID}:layer:${layerName}:${version}`;
+}
+
+export function getMissingRuntimeLayerErrorMsg(architecture: string) {
+  return (
+    `Unable to provide an extension layer for the architecture: ${architecture}` +
+    `Please ensure that a supported architecture is being provided.`
+  );
 }
 
 export function getMissingLayerVersionErrorMsg(functionKey: string, formalRuntime: string, paramRuntime: string) {


### PR DESCRIPTION
### What does this PR do?
This pr adds a check to validate if a proper architecture is defined when the layer is being added.  If an invalid architecture is specified an error is given to the user that it's invalid with a readout of the architecture they tried using. 

### Motivation
An escalation came through where a customer was confused why their code wasn't being deployed. it turned out they had mapping in place to substitute the architecture against their own non-standard versions. this mapping didn't work so the runtime value was becoming set as undefined

### Testing Guidelines

I tested the code block in chrome's dev tools to test functionality ensuring no syntax errors. 

### Additional Notes
N/A

### Types of changes

- [ ] Bug fix
- [ X] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
