### PR TITLE
feat: Replace hub with gh cli

### DIFF
--- a/serverless/release.sh
+++ b/serverless/release.sh
@@ -83,7 +83,7 @@ if [ "$PROD_RELEASE" = true ] ; then
     go get github.com/github/hub
     ./tools/build_zip.sh "${VERSION}"
 
-    hub release create -a .macro/serverless-macro-${VERSION}.zip -m "serverless-macro-${VERSION}" serverless-macro-${VERSION}
+    gh release create serverless-macro${VERSION} .macro/serverless-macro-${VERSION}.zip --generate-notes
     TEMPLATE_URL="https://${BUCKET}.s3.amazonaws.com/aws/serverless-macro/latest.yml"
     MACRO_SOURCE_URL="https://github.com/DataDog/datadog-cloudformation-macro/releases/download/serverless-macro-${VERSION}/serverless-macro-${VERSION}.zip'"
 else


### PR DESCRIPTION
### What does this PR do?

hub requires personal access tokens, which we shouldn't use anymore. It's also a community project.

We can do the exact same thing with the `gh` command line tool https://cli.github.com/

this is a drop in replacement and was used to release 0.9.0

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
