### PR TITLE
feat: add `python3.12` support

### DIFF
--- a/serverless/src/layer.ts
+++ b/serverless/src/layer.ts
@@ -50,6 +50,7 @@ export const runtimeLookup: { [key: string]: RuntimeType } = {
   "python3.9": RuntimeType.PYTHON,
   "python3.10": RuntimeType.PYTHON,
   "python3.11": RuntimeType.PYTHON,
+  "python3.12": RuntimeType.PYTHON,
 };
 
 function runtimeToLayerName(runtime: string, architecture: string): string {
@@ -69,6 +70,7 @@ function runtimeToLayerName(runtime: string, architecture: string): string {
     "python3.9": "Datadog-Python39",
     "python3.10": "Datadog-Python310",
     "python3.11": "Datadog-Python311",
+    "python3.12": "Datadog-Python312",
   };
 
   const pythonArmLookup: { [key: string]: string } = {
@@ -76,6 +78,7 @@ function runtimeToLayerName(runtime: string, architecture: string): string {
     "python3.9": "Datadog-Python39-ARM",
     "python3.10": "Datadog-Python310-ARM",
     "python3.11": "Datadog-Python311-ARM",
+    "python3.12": "Datadog-Python312-ARM",
   };
 
   if (runtimeLookup[runtime] === RuntimeType.NODE) {

--- a/serverless/test/layer.spec.ts
+++ b/serverless/test/layer.spec.ts
@@ -62,6 +62,7 @@ describe("findLambdas", () => {
       Python39Function: mockFunctionResource("python3.9", ["x86_64"]),
       Python310Function: mockFunctionResource("python3.10", ["x86_64"]),
       Python311Function: mockFunctionResource("python3.11", ["x86_64"]),
+      Python312Function: mockFunctionResource("python3.12", ["x86_64"]),
       GoFunction: mockFunctionResource("go1.10", ["x86_64"]),
       RefFunction: mockFunctionResource({ Ref: "ValueRef" }, ["arm64"]),
     };
@@ -80,6 +81,7 @@ describe("findLambdas", () => {
       mockLambdaFunction("Python39Function", "python3.9", RuntimeType.PYTHON, "x86_64", ArchitectureType.x86_64),
       mockLambdaFunction("Python310Function", "python3.10", RuntimeType.PYTHON, "x86_64", ArchitectureType.x86_64),
       mockLambdaFunction("Python311Function", "python3.11", RuntimeType.PYTHON, "x86_64", ArchitectureType.x86_64),
+      mockLambdaFunction("Python312Function", "python3.12", RuntimeType.PYTHON, "x86_64", ArchitectureType.x86_64),
       mockLambdaFunction("GoFunction", "go1.10", RuntimeType.UNSUPPORTED, "x86_64", ArchitectureType.x86_64),
       mockLambdaFunction("RefFunction", "nodejs14.x", RuntimeType.NODE, "arm64", ArchitectureType.ARM64, {
         Ref: "ValueRef",
@@ -178,7 +180,7 @@ describe("applyLayers", () => {
   });
 
   it("applies the python and extension lambda layers", () => {
-    const lambda = mockLambdaFunction("FunctionKey", "python3.6", RuntimeType.PYTHON, "x86_64");
+    const lambda = mockLambdaFunction("FunctionKey", "python3.12", RuntimeType.PYTHON, "x86_64");
     const region = "us-east-1";
     const pythonLayerVersion = 25;
     const extensionLayerVersion = 6;
@@ -186,7 +188,7 @@ describe("applyLayers", () => {
 
     expect(errors.length).toEqual(0);
     expect(lambda.properties.Layers).toEqual([
-      `arn:aws:lambda:${region}:${DD_ACCOUNT_ID}:layer:Datadog-Python36:${pythonLayerVersion}`,
+      `arn:aws:lambda:${region}:${DD_ACCOUNT_ID}:layer:Datadog-Python312:${pythonLayerVersion}`,
       `arn:aws:lambda:${region}:${DD_ACCOUNT_ID}:layer:Datadog-Extension:${extensionLayerVersion}`,
     ]);
   });


### PR DESCRIPTION
### What does this PR do?

Adds support for Python 3.12

### Motivation

We have [released](https://github.com/DataDog/datadog-lambda-python/releases/tag/v87) already the layers for this.

### Testing Guidelines

Updated a unit test.

### Additional Notes

n/a

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
