### PR TITLE
Adds dash to release version in release script

### DIFF
--- a/serverless/release.sh
+++ b/serverless/release.sh
@@ -83,7 +83,7 @@ if [ "$PROD_RELEASE" = true ] ; then
     go get github.com/github/hub
     ./tools/build_zip.sh "${VERSION}"
 
-    gh release create serverless-macro${VERSION} .macro/serverless-macro-${VERSION}.zip --generate-notes
+    gh release create serverless-macro-${VERSION} .macro/serverless-macro-${VERSION}.zip --generate-notes
     TEMPLATE_URL="https://${BUCKET}.s3.amazonaws.com/aws/serverless-macro/latest.yml"
     MACRO_SOURCE_URL="https://github.com/DataDog/datadog-cloudformation-macro/releases/download/serverless-macro-${VERSION}/serverless-macro-${VERSION}.zip'"
 else


### PR DESCRIPTION
### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

Adds a dash character `-` to the release version in the launch script so future release tags are consistent with previous versions.

### Motivation

<!--- What inspired you to submit this pull request? --->

Release tag was created with a different pattern than that of previous versions
* https://github.com/DataDog/datadog-cloudformation-macro/tree/serverless-macro0.10.0
* https://github.com/DataDog/datadog-cloudformation-macro/tree/serverless-macro-0.9.0

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
