### PR TITLE
feat: support `dotnet8` runtime

### DIFF
--- a/serverless/src/layer.ts
+++ b/serverless/src/layer.ts
@@ -41,6 +41,7 @@ const architectureToExtensionLayerName: { [key: string]: string } = {
 
 export const runtimeLookup: { [key: string]: RuntimeType } = {
   dotnet6: RuntimeType.DOTNET,
+  dotnet8: RuntimeType.DOTNET,
   java11: RuntimeType.JAVA,
   java17: RuntimeType.JAVA,
   java21: RuntimeType.JAVA,
@@ -64,6 +65,7 @@ export const runtimeLookup: { [key: string]: RuntimeType } = {
 export const layerNameLookup: { [key in ArchitectureType]: { [key: string]: string } } = {
   [ArchitectureType.x86_64]: {
     dotnet6: "dd-trace-dotnet",
+    dotnet8: "dd-trace-dotnet",
     java11: "dd-trace-java",
     java17: "dd-trace-java",
     java21: "dd-trace-java",
@@ -85,6 +87,7 @@ export const layerNameLookup: { [key in ArchitectureType]: { [key: string]: stri
   },
   [ArchitectureType.ARM64]: {
     dotnet6: "dd-trace-dotnet-ARM",
+    dotnet8: "dd-trace-dotnet-ARM",
     java11: "dd-trace-java",
     java17: "dd-trace-java",
     java21: "dd-trace-java",

--- a/serverless/test/layer.spec.ts
+++ b/serverless/test/layer.spec.ts
@@ -78,7 +78,7 @@ describe("findLambdas", () => {
 
     expect(lambdas).toEqual([
       mockLambdaFunction("Dotnet6Function", "dotnet6", RuntimeType.DOTNET, "x86_64", ArchitectureType.x86_64),
-      mockLambdaFunction("Dotnet6Function", "dotnet8", RuntimeType.DOTNET, "x86_64", ArchitectureType.x86_64),
+      mockLambdaFunction("Dotnet8Function", "dotnet8", RuntimeType.DOTNET, "x86_64", ArchitectureType.x86_64),
       mockLambdaFunction("Java11Function", "java11", RuntimeType.JAVA, "x86_64", ArchitectureType.x86_64),
       mockLambdaFunction("Java17Function", "java17", RuntimeType.JAVA, "x86_64", ArchitectureType.x86_64),
       mockLambdaFunction("Java21Function", "java21", RuntimeType.JAVA, "x86_64", ArchitectureType.x86_64),

--- a/serverless/test/layer.spec.ts
+++ b/serverless/test/layer.spec.ts
@@ -52,6 +52,7 @@ describe("findLambdas", () => {
   it("finds lambdas and correctly assigns runtime types", () => {
     const resources = {
       Dotnet6Function: mockFunctionResource("dotnet6", ["x86_64"]),
+      Dotnet8Function: mockFunctionResource("dotnet8", ["x86_64"]),
       Java11Function: mockFunctionResource("java11", ["x86_64"]),
       Java17Function: mockFunctionResource("java17", ["x86_64"]),
       Java21Function: mockFunctionResource("java21", ["x86_64"]),
@@ -77,6 +78,7 @@ describe("findLambdas", () => {
 
     expect(lambdas).toEqual([
       mockLambdaFunction("Dotnet6Function", "dotnet6", RuntimeType.DOTNET, "x86_64", ArchitectureType.x86_64),
+      mockLambdaFunction("Dotnet6Function", "dotnet8", RuntimeType.DOTNET, "x86_64", ArchitectureType.x86_64),
       mockLambdaFunction("Java11Function", "java11", RuntimeType.JAVA, "x86_64", ArchitectureType.x86_64),
       mockLambdaFunction("Java17Function", "java17", RuntimeType.JAVA, "x86_64", ArchitectureType.x86_64),
       mockLambdaFunction("Java21Function", "java21", RuntimeType.JAVA, "x86_64", ArchitectureType.x86_64),
@@ -264,7 +266,7 @@ describe("applyLayers", () => {
   });
 
   it("applies the dotnet and extension lambda layers", () => {
-    const lambda = mockLambdaFunction("FunctionKey", "dotnet6", RuntimeType.DOTNET, "x86_64");
+    const lambda = mockLambdaFunction("FunctionKey", "dotnet8", RuntimeType.DOTNET, "x86_64");
     const region = "us-east-1";
     const dotnetLayerVersion = 14;
     const extensionLayerVersion = 6;
@@ -286,7 +288,7 @@ describe("applyLayers", () => {
   });
 
   it("applies the dotnet and extension lambda layers for arm", () => {
-    const lambda = mockLambdaFunction("FunctionKey", "dotnet6", RuntimeType.DOTNET, "arm64", ArchitectureType.ARM64);
+    const lambda = mockLambdaFunction("FunctionKey", "dotnet8", RuntimeType.DOTNET, "arm64", ArchitectureType.ARM64);
     const region = "us-east-1";
     const dotnetLayerVersion = 14;
     const extensionLayerVersion = 6;


### PR DESCRIPTION
### What does this PR do?

Adds support for .NET 8 runtime.

### Motivation

It has been widely available for AWS Lambda.

### Testing Guidelines

Added and updated tests.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
