### PR TITLE
fix: revert node20, use node18 for govcloud

### DIFF
--- a/.github/workflows/build_serverless.yml
+++ b/.github/workflows/build_serverless.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 18
 
       - name: Cache Node modules
         id: cache-node-modules
@@ -59,7 +59,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 18 
 
       - name: Cache Node modules
         id: cache-node-modules

--- a/serverless/template.yml
+++ b/serverless/template.yml
@@ -58,7 +58,7 @@ Resources:
       Description: Processes a CloudFormation template to install Datadog Lambda layers for Python and Node.js Lambda functions.
       Timeout: 10
       Handler: src/index.handler
-      Runtime: nodejs20.x
+      Runtime: nodejs18.x
       CodeUri:
         Bucket: !Ref MacroFunctionZipsBucket
         Key:


### PR DESCRIPTION
### What does this PR do?
Govcloud does not support node20 yet, so we gotta use node18 for now.

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
