### PR TITLE
Allow the extension layer to be applied separately from the runtime layers

### DIFF
--- a/serverless/src/env.ts
+++ b/serverless/src/env.ts
@@ -255,6 +255,11 @@ export function validateParameters(config: Configuration) {
       "Warning: Invalid site URL. Must be either datadoghq.com, datadoghq.eu, us3.datadoghq.com, us5.datadoghq.com, ap1.datadoghq.com, or ddog-gov.com.",
     );
   }
+  if (config.addExtension === true) {
+    if (config.extensionLayerVersion === undefined) {
+      errors.push("Please add the 'extensionLayerVersion' parameter for the Datadog serverless macro");
+    }
+  }
   if (config.extensionLayerVersion !== undefined) {
     if (config.forwarderArn !== undefined) {
       errors.push("`extensionLayerVersion` and `forwarderArn` cannot be set at the same time.");
@@ -263,6 +268,7 @@ export function validateParameters(config: Configuration) {
       errors.push("When `extensionLayerVersion` is set, `apiKey`, `apiKeySecretArn`, or `apiKmsKey` must also be set.");
     }
   }
+
   return errors;
 }
 

--- a/serverless/src/env.ts
+++ b/serverless/src/env.ts
@@ -5,7 +5,7 @@ import log from "loglevel";
 export interface Configuration {
   // Whether to add the Datadog Lambda Library layers, or expect the users to bring their own
   addLayers: boolean;
-  // Whether to add the Datadog Extention Library layer
+  // Whether to add the Datadog Extension Library layer
   addExtension: boolean;
   // Python Lambda layer version
   pythonLayerVersion?: number;

--- a/serverless/src/env.ts
+++ b/serverless/src/env.ts
@@ -5,6 +5,8 @@ import log from "loglevel";
 export interface Configuration {
   // Whether to add the Datadog Lambda Library layers, or expect the users to bring their own
   addLayers: boolean;
+  // Whether to add the Datadog Extention Library layer
+  addExtension: boolean;
   // Python Lambda layer version
   pythonLayerVersion?: number;
   // Node.js Lambda layer version
@@ -109,6 +111,7 @@ const ddApmFlushDeadlineMillisecondsEnvVar = "DD_APM_FLUSH_DEADLINE_MILLISECONDS
 
 export const defaultConfiguration: Configuration = {
   addLayers: true,
+  addExtension: true,
   flushMetricsToLogs: true,
   logLevel: undefined,
   site: "datadoghq.com",

--- a/serverless/src/index.ts
+++ b/serverless/src/index.ts
@@ -1,5 +1,5 @@
 import { getConfigFromCfnMappings, getConfigFromCfnParams, setEnvConfiguration, validateParameters } from "./env";
-import { findLambdas, applyLayers, LambdaFunction } from "./layer";
+import { findLambdas, applyLayers, applyExtensionLayer, LambdaFunction } from "./layer";
 import { getTracingMode, enableTracing, MissingIamRoleError, TracingMode } from "./tracing";
 import { addDDTags, addMacroTag, addCDKTag, addSAMTag } from "./tags";
 import { redirectHandlers } from "./redirect";
@@ -106,7 +106,6 @@ export const handler = async (event: InputEvent, _: any) => {
         config.nodeLayerVersion,
         config.dotnetLayerVersion,
         config.javaLayerVersion,
-        config.extensionLayerVersion,
       );
       if (errors.length > 0) {
         return {
@@ -115,6 +114,22 @@ export const handler = async (event: InputEvent, _: any) => {
           fragment,
           errorMessage: errors.join("\n"),
         };
+      }
+    }
+
+    if(config.addExtension){
+      errors = applyExtensionLayer(
+        region,
+        lambdas,
+        config.extensionLayerVersion,
+      );
+      if(errors.length > 0){
+        return {
+          requestId: event.requestId,
+          status: FAILURE,
+          fragment,
+          errorMessage: errors.join("\n")
+        }
       }
     }
 

--- a/serverless/src/index.ts
+++ b/serverless/src/index.ts
@@ -117,19 +117,15 @@ export const handler = async (event: InputEvent, _: any) => {
       }
     }
 
-    if(config.addExtension){
-      errors = applyExtensionLayer(
-        region,
-        lambdas,
-        config.extensionLayerVersion,
-      );
-      if(errors.length > 0){
+    if (config.addExtension) {
+      errors = applyExtensionLayer(region, lambdas, config.extensionLayerVersion);
+      if (errors.length > 0) {
         return {
           requestId: event.requestId,
           status: FAILURE,
           fragment,
-          errorMessage: errors.join("\n")
-        }
+          errorMessage: errors.join("\n"),
+        };
       }
     }
 

--- a/serverless/src/layer.ts
+++ b/serverless/src/layer.ts
@@ -230,11 +230,7 @@ export function applyLayers(
   return errors;
 }
 
-export function applyExtensionLayer(
-  region: string, 
-  lambdas : LambdaFunction[],
-  extensionLayerVersion? : number,
-) {
+export function applyExtensionLayer(region: string, lambdas: LambdaFunction[], extensionLayerVersion?: number) {
   const errors: string[] = [];
   lambdas.forEach((lambda) => {
     let lambdaExtensionLayerArn;

--- a/serverless/src/layer.ts
+++ b/serverless/src/layer.ts
@@ -235,11 +235,14 @@ export function applyExtensionLayer(region: string, lambdas: LambdaFunction[], e
   lambdas.forEach((lambda) => {
     let lambdaExtensionLayerArn;
 
-    if (extensionLayerVersion !== undefined) {
-      log.debug(`Setting Lambda Extension layer for ${lambda.key}`);
-      lambdaExtensionLayerArn = getExtensionLayerArn(region, extensionLayerVersion, lambda.architecture);
-      addLayer(lambdaExtensionLayerArn, lambda);
+    if (extensionLayerVersion === undefined) {
+      errors.push(getMissingExtensionLayerVersionErrorMsg(lambda.key));
+      return;
     }
+
+    log.debug(`Setting Lambda Extension layer for ${lambda.key}`);
+    lambdaExtensionLayerArn = getExtensionLayerArn(region, extensionLayerVersion, lambda.architecture);
+    addLayer(lambdaExtensionLayerArn, lambda);
   });
   return errors;
 }
@@ -315,5 +318,12 @@ export function getMissingLayerVersionErrorMsg(functionKey: string, formalRuntim
   return (
     `Resource ${functionKey} has a ${formalRuntime} runtime, but no ${formalRuntime} Lambda Library version was provided. ` +
     `Please add the '${paramRuntime}LayerVersion' parameter for the Datadog serverless macro.`
+  );
+}
+
+export function getMissingExtensionLayerVersionErrorMsg(functionKey: string) {
+  return (
+    `Resource ${functionKey} has been configured to apply the extension laybe but no extension version was provided. ` +
+    `Please add the 'extensionLayerVersion' parameter for the Datadog serverless macro`
   );
 }

--- a/serverless/src/layer.ts
+++ b/serverless/src/layer.ts
@@ -173,7 +173,6 @@ export function applyLayers(
   nodeLayerVersion?: number,
   dotnetLayerVersion?: number,
   javaLayerVersion?: number,
-  extensionLayerVersion?: number,
 ) {
   const errors: string[] = [];
   lambdas.forEach((lambda) => {
@@ -183,7 +182,6 @@ export function applyLayers(
     }
 
     let lambdaLibraryLayerArn;
-    let lambdaExtensionLayerArn;
 
     if (lambda.runtimeType === RuntimeType.PYTHON) {
       if (pythonLayerVersion === undefined) {
@@ -228,6 +226,18 @@ export function applyLayers(
       lambdaLibraryLayerArn = getLambdaLibraryLayerArn(region, javaLayerVersion, lambda.runtime, lambda.architecture);
       addLayer(lambdaLibraryLayerArn, lambda);
     }
+  });
+  return errors;
+}
+
+export function applyExtensionLayer(
+  region: string, 
+  lambdas : LambdaFunction[],
+  extensionLayerVersion? : number,
+) {
+  const errors: string[] = [];
+  lambdas.forEach((lambda) => {
+    let lambdaExtensionLayerArn;
 
     if (extensionLayerVersion !== undefined) {
       log.debug(`Setting Lambda Extension layer for ${lambda.key}`);

--- a/serverless/template.yml
+++ b/serverless/template.yml
@@ -4,7 +4,7 @@ Transform: AWS::Serverless-2016-10-31
 Mappings:
   Constants:
     DatadogServerlessMacro:
-      Version: 0.13.0
+      Version: 0.15.0
 
 Parameters:
   FunctionName:

--- a/serverless/test/env.spec.ts
+++ b/serverless/test/env.spec.ts
@@ -269,7 +269,7 @@ describe("setEnvConfiguration", () => {
     };
     const config = {
       addLayers: false,
-      addExtension: true,
+      addExtension: false,
       apiKey: "1234",
       apiKMSKey: "5678",
       site: "datadoghq.eu",
@@ -558,7 +558,7 @@ describe("validateParameters", () => {
   it("returns an error when given an invalid site url", () => {
     const params = {
       addLayers: true,
-      addExtension: true,
+      addExtension: false,
       flushMetricsToLogs: true,
       logLevel: "info",
       site: "datacathq.com",
@@ -580,7 +580,7 @@ describe("validateParameters", () => {
   it("returns an error when extensionLayerVersion and forwarderArn are set", () => {
     const params = {
       addLayers: true,
-      addExtension: true,
+      addExtension: false,
       flushMetricsToLogs: true,
       logLevel: "info",
       site: "datadoghq.com",
@@ -595,6 +595,27 @@ describe("validateParameters", () => {
 
     const errors = validateParameters(params);
     expect(errors.includes("`extensionLayerVersion` and `forwarderArn` cannot be set at the same time.")).toBe(true);
+  });
+
+  it("returns an error when extensionLayer is true without setting extensionLayerVersion", () => {
+    const params = {
+      addLayers: true,
+      addExtension: true,
+      flushMetricsToLogs: true,
+      logLevel: "info",
+      site: "datadoghq.com",
+      enableXrayTracing: false,
+      enableDDTracing: true,
+      enableDDLogs: true,
+      enableEnhancedMetrics: true,
+      forwarderArn: "test-forwarder",
+      captureLambdaPayload: false,
+    };
+
+    const errors = validateParameters(params);
+    expect(errors.includes("Please add the 'extensionLayerVersion' parameter for the Datadog serverless macro")).toBe(
+      true,
+    );
   });
 
   it("returns an error when extensionLayerVersion is set but neither apiKey nor apiKMSKey is set", () => {
@@ -623,7 +644,7 @@ describe("validateParameters", () => {
   it("returns an error when multiple api keys are set", () => {
     const params = {
       addLayers: true,
-      addExtension: true,
+      addExtension: false,
       apiKey: "1234",
       apiKMSKey: "5678",
       flushMetricsToLogs: true,
@@ -643,7 +664,7 @@ describe("validateParameters", () => {
   it("works with ap1", () => {
     const params = {
       addLayers: true,
-      addExtension: true,
+      addExtension: false,
       apiKey: "1234",
       flushMetricsToLogs: true,
       logLevel: "info",

--- a/serverless/test/env.spec.ts
+++ b/serverless/test/env.spec.ts
@@ -33,6 +33,7 @@ describe("getConfig", () => {
     const config = getConfigFromCfnParams(params);
     expect(config).toEqual({
       addLayers: true,
+      addExtension: true,
       flushMetricsToLogs: true,
       site: "my-site",
       enableXrayTracing: false,
@@ -62,6 +63,7 @@ describe("getConfig", () => {
       const config = getConfigFromEnvVars();
       expect(config).toEqual({
         addLayers: true,
+        addExtension: true,
         flushMetricsToLogs: false,
         logLevel: undefined,
         site: "datadoghq.com",
@@ -89,6 +91,7 @@ describe("getConfig", () => {
       const config = getConfigFromCfnParams(params);
       expect(config).toEqual({
         addLayers: true,
+        addExtension: true,
         flushMetricsToLogs: false,
         site: "my-site",
         enableXrayTracing: false,
@@ -199,6 +202,7 @@ describe("setEnvConfiguration", () => {
     };
     const config = {
       addLayers: false,
+      addExtension: false,
       apiKey: "1234",
       apiKMSKey: "5678",
       site: "datadoghq.eu",
@@ -265,6 +269,7 @@ describe("setEnvConfiguration", () => {
     };
     const config = {
       addLayers: false,
+      addExtension: true,
       apiKey: "1234",
       apiKMSKey: "5678",
       site: "datadoghq.eu",
@@ -350,6 +355,7 @@ describe("setEnvConfiguration", () => {
     };
     const config = {
       addLayers: false,
+      addExtension: false,
       apiKey: "abcd",
       apiKMSKey: "efgh",
       site: "datadoghq.com",
@@ -396,6 +402,7 @@ describe("setEnvConfiguration", () => {
     };
     const config = {
       addLayers: false,
+      addExtension: false,
       apiKey: "1234",
       apiKMSKey: "5678",
       site: "datadoghq.eu",
@@ -438,6 +445,7 @@ describe("setEnvConfiguration", () => {
     };
     const config = {
       addLayers: false,
+      addExtension: false,
       apiKey: "1234",
       apiKMSKey: "5678",
       site: "datadoghq.eu",
@@ -482,6 +490,7 @@ describe("setEnvConfiguration", () => {
     };
     const config = {
       addLayers: false,
+      addExtension: false,
       apiKeySecretArn: "some-resource:from:aws:secrets-manager:arn",
       site: "datadoghq.eu",
       logLevel: "info",
@@ -525,6 +534,7 @@ describe("setEnvConfiguration", () => {
     };
     const config = {
       addLayers: false,
+      addExtension: false,
       apiKeySecretArn: "some-resource:from:aws:secrets-manager:arn",
       site: "datadoghq.eu",
       logLevel: "info",
@@ -548,6 +558,7 @@ describe("validateParameters", () => {
   it("returns an error when given an invalid site url", () => {
     const params = {
       addLayers: true,
+      addExtension: true,
       flushMetricsToLogs: true,
       logLevel: "info",
       site: "datacathq.com",
@@ -569,6 +580,7 @@ describe("validateParameters", () => {
   it("returns an error when extensionLayerVersion and forwarderArn are set", () => {
     const params = {
       addLayers: true,
+      addExtension: true,
       flushMetricsToLogs: true,
       logLevel: "info",
       site: "datadoghq.com",
@@ -588,6 +600,7 @@ describe("validateParameters", () => {
   it("returns an error when extensionLayerVersion is set but neither apiKey nor apiKMSKey is set", () => {
     const params = {
       addLayers: true,
+      addExtension: true,
       flushMetricsToLogs: true,
       logLevel: "info",
       site: "datadoghq.com",
@@ -610,6 +623,7 @@ describe("validateParameters", () => {
   it("returns an error when multiple api keys are set", () => {
     const params = {
       addLayers: true,
+      addExtension: true,
       apiKey: "1234",
       apiKMSKey: "5678",
       flushMetricsToLogs: true,
@@ -629,6 +643,7 @@ describe("validateParameters", () => {
   it("works with ap1", () => {
     const params = {
       addLayers: true,
+      addExtension: true,
       apiKey: "1234",
       flushMetricsToLogs: true,
       logLevel: "info",
@@ -651,6 +666,7 @@ describe("checkForMultipleApiKeys", () => {
     expect(
       checkForMultipleApiKeys({
         addLayers: false,
+        addExtension: false,
         apiKey: "1234",
         apiKMSKey: "5678",
         logLevel: "debug",
@@ -669,6 +685,7 @@ describe("checkForMultipleApiKeys", () => {
     expect(
       checkForMultipleApiKeys({
         addLayers: false,
+        addExtension: false,
         apiKey: "5678",
         apiKeySecretArn: "some-resource:from:aws:secrets-manager:arn",
         logLevel: "debug",
@@ -687,6 +704,7 @@ describe("checkForMultipleApiKeys", () => {
     expect(
       checkForMultipleApiKeys({
         addLayers: false,
+        addExtension: false,
         apiKeySecretArn: "some-resource:from:aws:secrets-manager:arn",
         apiKMSKey: "5678",
         logLevel: "debug",
@@ -705,6 +723,7 @@ describe("checkForMultipleApiKeys", () => {
     expect(
       checkForMultipleApiKeys({
         addLayers: false,
+        addExtension: false,
         apiKey: "1234",
         apiKeySecretArn: "some-resource:from:aws:secrets-manager:arn",
         apiKMSKey: "5678",

--- a/serverless/test/index.spec.ts
+++ b/serverless/test/index.spec.ts
@@ -135,7 +135,7 @@ function mockGovCloudInputEvent(params: any, mappings: any, logGroups?: LogGroup
 describe("Macro", () => {
   describe("parameters and config", () => {
     it("uses transform parameters if they are provided", async () => {
-      const transformParams = { site: "datadoghq.com" };
+      const transformParams = { site: "datadoghq.com", addExtension: false };
       const mappings = {
         Datadog: {
           Parameters: { site: "mappings-site" },
@@ -153,7 +153,7 @@ describe("Macro", () => {
     it("uses parameters under Mappings section if template parameters are not given", async () => {
       const mappings = {
         Datadog: {
-          Parameters: { site: "datadoghq.eu" },
+          Parameters: { site: "datadoghq.eu", addExtension: false },
         },
       };
       const inputEvent = mockInputEvent({}, mappings);
@@ -168,7 +168,7 @@ describe("Macro", () => {
 
   describe("lambda layers", () => {
     it("adds lambda layers by default", async () => {
-      const params = { nodeLayerVersion: 25 };
+      const params = { nodeLayerVersion: 25, addExtension: false };
       const inputEvent = mockInputEvent(params, {}); // Use default configuration
       const output = await handler(inputEvent, {});
       const lambdaProperties: FunctionProperties = output.fragment.Resources[LAMBDA_KEY].Properties;
@@ -180,7 +180,8 @@ describe("Macro", () => {
     });
 
     it("macro fails when corresponding lambda layer version is not provided", async () => {
-      const inputEvent = mockInputEvent({}, {}); // Use default configuration, no lambda layer version provided
+      const params = { addExtension: false };
+      const inputEvent = mockInputEvent(params, {}); // Use default configuration, no lambda layer version provided
       const output = await handler(inputEvent, {});
 
       expect(output.status).toEqual("failure");
@@ -188,7 +189,7 @@ describe("Macro", () => {
     });
 
     it("skips adding lambda layers when addLayers is false", async () => {
-      const params = { addLayers: false };
+      const params = { addLayers: false, addExtension: false };
       const inputEvent = mockInputEvent(params, {});
       const output = await handler(inputEvent, {});
       const lambdaProperties: FunctionProperties = output.fragment.Resources[LAMBDA_KEY].Properties;
@@ -197,7 +198,7 @@ describe("Macro", () => {
     });
 
     it("uses the GovCloud layer when a GovCloud region is detected", async () => {
-      const params = { nodeLayerVersion: 25 };
+      const params = { nodeLayerVersion: 25, addExtension: false };
       const inputEvent = mockGovCloudInputEvent(params, {});
       const output = await handler(inputEvent, {});
       const lambdaProperties: FunctionProperties = output.fragment.Resources[LAMBDA_KEY].Properties;
@@ -210,7 +211,7 @@ describe("Macro", () => {
 
   describe("tracing", () => {
     it("skips adding tracing when enableXrayTracing is false", async () => {
-      const params = { enableXrayTracing: false };
+      const params = { enableXrayTracing: false, addExtension: false };
       const inputEvent = mockInputEvent(params, {});
       const output = await handler(inputEvent, {});
       const iamRole: IamRoleProperties = output.fragment.Resources[`${LAMBDA_KEY}Role`].Properties;
@@ -223,7 +224,12 @@ describe("Macro", () => {
 
   describe("CloudWatch subscriptions", () => {
     it("adds subscription filters when forwarder is provided", async () => {
-      const params = { forwarderArn: "forwarder-arn", stackName: "stack-name", nodeLayerVersion: 25 };
+      const params = {
+        forwarderArn: "forwarder-arn",
+        stackName: "stack-name",
+        nodeLayerVersion: 25,
+        addExtension: false,
+      };
       const inputEvent = mockInputEvent(params, {});
       await handler(inputEvent, {});
 
@@ -233,7 +239,7 @@ describe("Macro", () => {
     });
 
     it("macro fails when forwarder is provided & at least one lambda has a dynamically generated name, but no stack name is given", async () => {
-      const params = { forwarderArn: "forwarder-arn", nodeLayerVersion: 25 };
+      const params = { forwarderArn: "forwarder-arn", nodeLayerVersion: 25, addExtension: false };
       const inputEvent = mockInputEvent(params, {});
       const output = await handler(inputEvent, {});
 
@@ -244,7 +250,7 @@ describe("Macro", () => {
 
   describe("tags", () => {
     it("only adds macro version tag when neither 'service' nor 'env' are provided", async () => {
-      const params = { nodeLayerVersion: 25 };
+      const params = { nodeLayerVersion: 25, addExtension: false };
       const inputEvent = mockInputEvent(params, {});
       const output = await handler(inputEvent, {});
       const lambdaProperties: FunctionProperties = output.fragment.Resources[LAMBDA_KEY].Properties;
@@ -253,7 +259,7 @@ describe("Macro", () => {
     });
 
     it("only adds cdk created tag when CDKMetadata is present", async () => {
-      const params = { nodeLayerVersion: 25 };
+      const params = { nodeLayerVersion: 25, addExtension: false };
       const inputEvent = mockInputEvent(params, {}, undefined, true);
       const output = await handler(inputEvent, {});
       const lambdaProperties: FunctionProperties = output.fragment.Resources[LAMBDA_KEY].Properties;
@@ -265,7 +271,7 @@ describe("Macro", () => {
     });
 
     it("only adds SAM created tag when lambda:createdBy:SAM tag is present", async () => {
-      const params = { nodeLayerVersion: 25 };
+      const params = { nodeLayerVersion: 25, addExtension: false };
       const inputEvent = mockInputEvent(params, {}, undefined, false, true);
       const output = await handler(inputEvent, {});
       const lambdaProperties: FunctionProperties = output.fragment.Resources[LAMBDA_KEY].Properties;
@@ -286,6 +292,7 @@ describe("Macro", () => {
         forwarderArn: "forwarder-arn",
         stackName: "stack-name",
         nodeLayerVersion: 25,
+        addExtension: false,
       };
       const inputEvent = mockInputEvent(params, {});
       const output = await handler(inputEvent, {});
@@ -308,6 +315,7 @@ describe("Macro", () => {
         version: "1",
         tags: "team:avengers,project:marvel",
         nodeLayerVersion: 25,
+        addExtension: false,
       };
       const inputEvent = mockInputEvent(params, {});
       const output = await handler(inputEvent, {});

--- a/serverless/test/layer.spec.ts
+++ b/serverless/test/layer.spec.ts
@@ -3,6 +3,7 @@ import {
   LambdaFunction,
   RuntimeType,
   applyLayers,
+  applyExtensionLayer,
   DD_ACCOUNT_ID,
   DD_GOV_ACCOUNT_ID,
   getMissingLayerVersionErrorMsg,
@@ -189,7 +190,14 @@ describe("applyLayers", () => {
       nodeLayerVersion,
       undefined,
       undefined,
-      extensionLayerVersion,
+    );
+
+    errors.concat(
+      applyExtensionLayer(
+        region,
+        [lambda],
+        extensionLayerVersion,
+      )
     );
 
     expect(errors.length).toEqual(0);
@@ -211,7 +219,14 @@ describe("applyLayers", () => {
       nodeLayerVersion,
       undefined,
       undefined,
-      extensionLayerVersion,
+    );
+
+    errors.concat(
+      applyExtensionLayer(
+        region,
+        [lambda],
+        extensionLayerVersion,
+      )
     );
 
     expect(errors.length).toEqual(0);
@@ -233,7 +248,14 @@ describe("applyLayers", () => {
       undefined,
       undefined,
       undefined,
-      extensionLayerVersion,
+    );
+    
+    errors.concat(
+      applyExtensionLayer(
+        region,
+        [lambda],
+        extensionLayerVersion,
+      )
     );
 
     expect(errors.length).toEqual(0);
@@ -255,7 +277,14 @@ describe("applyLayers", () => {
       undefined,
       undefined,
       undefined,
-      extensionLayerVersion,
+    );
+    
+    errors.concat(
+      applyExtensionLayer(
+        region,
+        [lambda],
+        extensionLayerVersion,
+      )
     );
 
     expect(errors.length).toEqual(0);
@@ -277,7 +306,14 @@ describe("applyLayers", () => {
       undefined,
       dotnetLayerVersion,
       undefined,
-      extensionLayerVersion,
+    );
+
+    errors.concat(
+      applyExtensionLayer(
+        region,
+        [lambda],
+        extensionLayerVersion,
+      )
     );
 
     expect(errors.length).toEqual(0);
@@ -299,7 +335,14 @@ describe("applyLayers", () => {
       undefined,
       dotnetLayerVersion,
       undefined,
-      extensionLayerVersion,
+    );
+    
+    errors.concat(
+      applyExtensionLayer(
+        region,
+        [lambda],
+        extensionLayerVersion,
+      )
     );
 
     expect(errors.length).toEqual(0);
@@ -321,7 +364,14 @@ describe("applyLayers", () => {
       undefined,
       undefined,
       javaLayerVersion,
-      extensionLayerVersion,
+    );
+    
+    errors.concat(
+      applyExtensionLayer(
+        region,
+        [lambda],
+        extensionLayerVersion,
+      )
     );
 
     expect(errors.length).toEqual(0);
@@ -343,8 +393,16 @@ describe("applyLayers", () => {
       undefined,
       undefined,
       javaLayerVersion,
-      extensionLayerVersion,
     );
+    
+    errors.concat(
+      applyExtensionLayer(
+        region,
+        [lambda],
+        extensionLayerVersion,
+      )
+    );
+    
 
     expect(errors.length).toEqual(0);
     expect(lambda.properties.Layers).toEqual([

--- a/serverless/test/layer.spec.ts
+++ b/serverless/test/layer.spec.ts
@@ -402,7 +402,6 @@ describe("applyLayers", () => {
         extensionLayerVersion,
       )
     );
-    
 
     expect(errors.length).toEqual(0);
     expect(lambda.properties.Layers).toEqual([

--- a/serverless/test/layer.spec.ts
+++ b/serverless/test/layer.spec.ts
@@ -183,22 +183,9 @@ describe("applyLayers", () => {
     const region = "us-east-1";
     const nodeLayerVersion = 25;
     const extensionLayerVersion = 6;
-    const errors = applyLayers(
-      region,
-      [lambda],
-      undefined,
-      nodeLayerVersion,
-      undefined,
-      undefined,
-    );
+    const errors = applyLayers(region, [lambda], undefined, nodeLayerVersion, undefined, undefined);
 
-    errors.concat(
-      applyExtensionLayer(
-        region,
-        [lambda],
-        extensionLayerVersion,
-      )
-    );
+    errors.concat(applyExtensionLayer(region, [lambda], extensionLayerVersion));
 
     expect(errors.length).toEqual(0);
     expect(lambda.properties.Layers).toEqual([
@@ -212,22 +199,9 @@ describe("applyLayers", () => {
     const region = "us-east-1";
     const nodeLayerVersion = 25;
     const extensionLayerVersion = 6;
-    const errors = applyLayers(
-      region,
-      [lambda],
-      undefined,
-      nodeLayerVersion,
-      undefined,
-      undefined,
-    );
+    const errors = applyLayers(region, [lambda], undefined, nodeLayerVersion, undefined, undefined);
 
-    errors.concat(
-      applyExtensionLayer(
-        region,
-        [lambda],
-        extensionLayerVersion,
-      )
-    );
+    errors.concat(applyExtensionLayer(region, [lambda], extensionLayerVersion));
 
     expect(errors.length).toEqual(0);
     expect(lambda.properties.Layers).toEqual([
@@ -241,22 +215,9 @@ describe("applyLayers", () => {
     const region = "us-east-1";
     const pythonLayerVersion = 25;
     const extensionLayerVersion = 6;
-    const errors = applyLayers(
-      region,
-      [lambda],
-      pythonLayerVersion,
-      undefined,
-      undefined,
-      undefined,
-    );
-    
-    errors.concat(
-      applyExtensionLayer(
-        region,
-        [lambda],
-        extensionLayerVersion,
-      )
-    );
+    const errors = applyLayers(region, [lambda], pythonLayerVersion, undefined, undefined, undefined);
+
+    errors.concat(applyExtensionLayer(region, [lambda], extensionLayerVersion));
 
     expect(errors.length).toEqual(0);
     expect(lambda.properties.Layers).toEqual([
@@ -270,22 +231,9 @@ describe("applyLayers", () => {
     const region = "us-east-1";
     const pythonLayerVersion = 25;
     const extensionLayerVersion = 6;
-    const errors = applyLayers(
-      region,
-      [lambda],
-      pythonLayerVersion,
-      undefined,
-      undefined,
-      undefined,
-    );
-    
-    errors.concat(
-      applyExtensionLayer(
-        region,
-        [lambda],
-        extensionLayerVersion,
-      )
-    );
+    const errors = applyLayers(region, [lambda], pythonLayerVersion, undefined, undefined, undefined);
+
+    errors.concat(applyExtensionLayer(region, [lambda], extensionLayerVersion));
 
     expect(errors.length).toEqual(0);
     expect(lambda.properties.Layers).toEqual([
@@ -299,22 +247,9 @@ describe("applyLayers", () => {
     const region = "us-east-1";
     const dotnetLayerVersion = 14;
     const extensionLayerVersion = 6;
-    const errors = applyLayers(
-      region,
-      [lambda],
-      undefined,
-      undefined,
-      dotnetLayerVersion,
-      undefined,
-    );
+    const errors = applyLayers(region, [lambda], undefined, undefined, dotnetLayerVersion, undefined);
 
-    errors.concat(
-      applyExtensionLayer(
-        region,
-        [lambda],
-        extensionLayerVersion,
-      )
-    );
+    errors.concat(applyExtensionLayer(region, [lambda], extensionLayerVersion));
 
     expect(errors.length).toEqual(0);
     expect(lambda.properties.Layers).toEqual([
@@ -328,22 +263,9 @@ describe("applyLayers", () => {
     const region = "us-east-1";
     const dotnetLayerVersion = 14;
     const extensionLayerVersion = 6;
-    const errors = applyLayers(
-      region,
-      [lambda],
-      undefined,
-      undefined,
-      dotnetLayerVersion,
-      undefined,
-    );
-    
-    errors.concat(
-      applyExtensionLayer(
-        region,
-        [lambda],
-        extensionLayerVersion,
-      )
-    );
+    const errors = applyLayers(region, [lambda], undefined, undefined, dotnetLayerVersion, undefined);
+
+    errors.concat(applyExtensionLayer(region, [lambda], extensionLayerVersion));
 
     expect(errors.length).toEqual(0);
     expect(lambda.properties.Layers).toEqual([
@@ -357,22 +279,9 @@ describe("applyLayers", () => {
     const region = "us-east-1";
     const javaLayerVersion = 12;
     const extensionLayerVersion = 6;
-    const errors = applyLayers(
-      region,
-      [lambda],
-      undefined,
-      undefined,
-      undefined,
-      javaLayerVersion,
-    );
-    
-    errors.concat(
-      applyExtensionLayer(
-        region,
-        [lambda],
-        extensionLayerVersion,
-      )
-    );
+    const errors = applyLayers(region, [lambda], undefined, undefined, undefined, javaLayerVersion);
+
+    errors.concat(applyExtensionLayer(region, [lambda], extensionLayerVersion));
 
     expect(errors.length).toEqual(0);
     expect(lambda.properties.Layers).toEqual([
@@ -386,22 +295,9 @@ describe("applyLayers", () => {
     const region = "us-east-1";
     const javaLayerVersion = 12;
     const extensionLayerVersion = 6;
-    const errors = applyLayers(
-      region,
-      [lambda],
-      undefined,
-      undefined,
-      undefined,
-      javaLayerVersion,
-    );
-    
-    errors.concat(
-      applyExtensionLayer(
-        region,
-        [lambda],
-        extensionLayerVersion,
-      )
-    );
+    const errors = applyLayers(region, [lambda], undefined, undefined, undefined, javaLayerVersion);
+
+    errors.concat(applyExtensionLayer(region, [lambda], extensionLayerVersion));
 
     expect(errors.length).toEqual(0);
     expect(lambda.properties.Layers).toEqual([


### PR DESCRIPTION
### What does this PR do?
Currently there is no way to deploy with the cloudformation macro and only apply the extension. 
This PR adds this ability when the user sets `addLayers` to `false` the extension will still be applied.
To override this feature a new configuration option has been made called 'addExtension`.
This defaults to `true` ensuring the extension layer is applied. 

### Motivation
Currently if a customer is providing their own lambda libraries (dd-trace, datadog-lambda-js) there is no way to exclude these layers from the deployment and still retain the extension layer. This adds that functionality for this edge case.

### Testing Guidelines
In addition to the unit tests i used the release tool to upload my changes to a staging bucket that hosted the macro. Which i deployed to a sandbox aws environment and then created a new function using the macro. I had set `addLayers` to `false` along with leaving `addExtension` to default. This produced a lambda with just the extension layer. 

I then modified my template.yaml file to set `addExtension` to `false` this resulted in no lambda's being added.

### Additional Notes
I did not increment the version number in the template yaml file.

One thing to consider is that users that have `addLayers` to `false` today and redeploy the macro will see a change in the expected behavior. 

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
