### PR TITLE
Setting addExtension to default to false

### DIFF
--- a/serverless/src/env.ts
+++ b/serverless/src/env.ts
@@ -257,12 +257,12 @@ export function validateParameters(config: Configuration) {
   }
   if (config.addExtension === true) {
     if (config.extensionLayerVersion === undefined) {
-      errors.push("Please add the 'extensionLayerVersion' parameter for the Datadog serverless macro");
+      errors.push("Please add the `extensionLayerVersion` parameter when `addExtension` is set.");
     }
   }
   if (config.extensionLayerVersion !== undefined) {
     if (config.forwarderArn !== undefined) {
-      errors.push("`extensionLayerVersion` and `forwarderArn` cannot be set at the same time.");
+      errors.push("setting `forwarderArn` with `addExtension` and/or `extensionLayerVersion` as these parameters cannot be set at the same time.");
     }
     if (config.apiKey === undefined && config.apiKeySecretArn === undefined && config.apiKMSKey === undefined) {
       errors.push("When `extensionLayerVersion` is set, `apiKey`, `apiKeySecretArn`, or `apiKmsKey` must also be set.");

--- a/serverless/src/env.ts
+++ b/serverless/src/env.ts
@@ -111,7 +111,7 @@ const ddApmFlushDeadlineMillisecondsEnvVar = "DD_APM_FLUSH_DEADLINE_MILLISECONDS
 
 export const defaultConfiguration: Configuration = {
   addLayers: true,
-  addExtension: true,
+  addExtension: false,
   flushMetricsToLogs: true,
   logLevel: undefined,
   site: "datadoghq.com",

--- a/serverless/src/env.ts
+++ b/serverless/src/env.ts
@@ -262,7 +262,9 @@ export function validateParameters(config: Configuration) {
   }
   if (config.extensionLayerVersion !== undefined) {
     if (config.forwarderArn !== undefined) {
-      errors.push("setting `forwarderArn` with `addExtension` and/or `extensionLayerVersion` as these parameters cannot be set at the same time.");
+      errors.push(
+        "setting `forwarderArn` with `addExtension` and/or `extensionLayerVersion` as these parameters cannot be set at the same time.",
+      );
     }
     if (config.apiKey === undefined && config.apiKeySecretArn === undefined && config.apiKMSKey === undefined) {
       errors.push("When `extensionLayerVersion` is set, `apiKey`, `apiKeySecretArn`, or `apiKmsKey` must also be set.");

--- a/serverless/src/index.ts
+++ b/serverless/src/index.ts
@@ -89,7 +89,6 @@ export const handler = async (event: InputEvent, _: any) => {
       };
     }
 
-    //
     const lambdas = findLambdas(resources, event.templateParameterValues);
     log.debug(`Lambda resources found: ${JSON.stringify(lambdas)}`);
 
@@ -117,7 +116,7 @@ export const handler = async (event: InputEvent, _: any) => {
       }
     }
 
-    if (config.addExtension) {
+    if (config.addExtension || config.extensionLayerVersion !== undefined) {
       errors = applyExtensionLayer(region, lambdas, config.extensionLayerVersion);
       if (errors.length > 0) {
         return {

--- a/serverless/test/env.spec.ts
+++ b/serverless/test/env.spec.ts
@@ -33,7 +33,7 @@ describe("getConfig", () => {
     const config = getConfigFromCfnParams(params);
     expect(config).toEqual({
       addLayers: true,
-      addExtension: true,
+      addExtension: false,
       flushMetricsToLogs: true,
       site: "my-site",
       enableXrayTracing: false,
@@ -63,7 +63,7 @@ describe("getConfig", () => {
       const config = getConfigFromEnvVars();
       expect(config).toEqual({
         addLayers: true,
-        addExtension: true,
+        addExtension: false,
         flushMetricsToLogs: false,
         logLevel: undefined,
         site: "datadoghq.com",
@@ -91,7 +91,7 @@ describe("getConfig", () => {
       const config = getConfigFromCfnParams(params);
       expect(config).toEqual({
         addLayers: true,
-        addExtension: true,
+        addExtension: false,
         flushMetricsToLogs: false,
         site: "my-site",
         enableXrayTracing: false,
@@ -621,7 +621,7 @@ describe("validateParameters", () => {
   it("returns an error when extensionLayerVersion is set but neither apiKey nor apiKMSKey is set", () => {
     const params = {
       addLayers: true,
-      addExtension: true,
+      addExtension: false,
       flushMetricsToLogs: true,
       logLevel: "info",
       site: "datadoghq.com",

--- a/serverless/test/env.spec.ts
+++ b/serverless/test/env.spec.ts
@@ -594,7 +594,7 @@ describe("validateParameters", () => {
     };
 
     const errors = validateParameters(params);
-    expect(errors.includes("`extensionLayerVersion` and `forwarderArn` cannot be set at the same time.")).toBe(true);
+    expect(errors.includes("setting `forwarderArn` with `addExtension` and/or `extensionLayerVersion` as these parameters cannot be set at the same time.")).toBe(true);
   });
 
   it("returns an error when extensionLayer is true without setting extensionLayerVersion", () => {
@@ -613,7 +613,7 @@ describe("validateParameters", () => {
     };
 
     const errors = validateParameters(params);
-    expect(errors.includes("Please add the 'extensionLayerVersion' parameter for the Datadog serverless macro")).toBe(
+    expect(errors.includes("Please add the `extensionLayerVersion` parameter when `addExtension` is set.")).toBe(
       true,
     );
   });

--- a/serverless/test/env.spec.ts
+++ b/serverless/test/env.spec.ts
@@ -594,7 +594,11 @@ describe("validateParameters", () => {
     };
 
     const errors = validateParameters(params);
-    expect(errors.includes("setting `forwarderArn` with `addExtension` and/or `extensionLayerVersion` as these parameters cannot be set at the same time.")).toBe(true);
+    expect(
+      errors.includes(
+        "setting `forwarderArn` with `addExtension` and/or `extensionLayerVersion` as these parameters cannot be set at the same time.",
+      ),
+    ).toBe(true);
   });
 
   it("returns an error when extensionLayer is true without setting extensionLayerVersion", () => {
@@ -613,9 +617,7 @@ describe("validateParameters", () => {
     };
 
     const errors = validateParameters(params);
-    expect(errors.includes("Please add the `extensionLayerVersion` parameter when `addExtension` is set.")).toBe(
-      true,
-    );
+    expect(errors.includes("Please add the `extensionLayerVersion` parameter when `addExtension` is set.")).toBe(true);
   });
 
   it("returns an error when extensionLayerVersion is set but neither apiKey nor apiKMSKey is set", () => {

--- a/serverless/test/index.spec.ts
+++ b/serverless/test/index.spec.ts
@@ -188,8 +188,20 @@ describe("Macro", () => {
       expect(output.errorMessage).toEqual(getMissingLayerVersionErrorMsg(LAMBDA_KEY, "Node.js", "node"));
     });
 
-    it("Adding only the extension layer", async () => {
+    it("add only the extension layer", async () => {
       const params = { addLayers: false, addExtension: true, extensionLayerVersion: 6, apiKey: "abc123" };
+      const inputEvent = mockInputEvent(params, {});
+      const output = await handler(inputEvent, {});
+      const lambdaProperties: FunctionProperties = output.fragment.Resources[LAMBDA_KEY].Properties;
+
+      // Mocked Lambda has the addExtension parameter to true and extensionLayerVersion to 6.
+      expect(lambdaProperties.Layers).toEqual([
+        expect.stringMatching(/arn:aws:lambda:us-east-1:.*:layer:Datadog-Extension:6/),
+      ]);
+    });
+
+    it("add only the extension layer only setting the extension layer version", async () => {
+      const params = { addLayers: false, extensionLayerVersion: 6, apiKey: "abc123" };
       const inputEvent = mockInputEvent(params, {});
       const output = await handler(inputEvent, {});
       const lambdaProperties: FunctionProperties = output.fragment.Resources[LAMBDA_KEY].Properties;


### PR DESCRIPTION
### What does this PR do?
This pr sets the parameter `addExtension` to default to `false`.

### Motivation
Because this parameter requires additional parameters to operate. it can cause issues to existing workflows where the user might not intend to add the extension layer. 

This addresses #133 
### Testing Guidelines
Wrote tests that operate through the various configurations. 

### Additional Notes


### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
