### PR TITLE
Golang support

### DIFF
--- a/serverless/src/index.ts
+++ b/serverless/src/index.ts
@@ -56,6 +56,7 @@ export interface FunctionProperties {
   FunctionName?: string;
   Architectures?: [string];
   PackageType?: string;
+  Metadata?: { [key: string]: string };
 }
 
 export const handler = async (event: InputEvent, _: any) => {

--- a/serverless/src/layer.ts
+++ b/serverless/src/layer.ts
@@ -62,6 +62,14 @@ export const runtimeLookup: { [key: string]: RuntimeType } = {
   "python3.12": RuntimeType.PYTHON,
 };
 
+export const agnosticRuntimes: string[] = [
+  "provided.al2",
+  "provided.al2023",
+]
+
+export const runtimeMetadataLookup: { [key: string]: RuntimeType } = {
+};
+
 export const layerNameLookup: { [key in ArchitectureType]: { [key: string]: string } } = {
   [ArchitectureType.x86_64]: {
     dotnet6: "dd-trace-dotnet",
@@ -131,12 +139,18 @@ export function findLambdas(resources: Resources, templateParameterValues: Param
 
       const runtime = useOrRef(properties.Runtime, templateParameterValues);
       const architecture = useOrRef(properties.Architectures?.[0], templateParameterValues) ?? "x86_64";
+      const metadataRuntime : string | undefined = useOrRef((properties.Metadata ?? {})["Runtime"], templateParameterValues);
 
       let runtimeType = RuntimeType.UNSUPPORTED;
       let architectureType = ArchitectureType.x86_64;
 
-      if (runtime !== undefined && runtime in runtimeLookup) {
-        runtimeType = runtimeLookup[runtime];
+      if (runtime !== undefined) {
+        if (runtime in runtimeLookup) {
+          runtimeType = runtimeLookup[runtime];
+        }
+        if (agnosticRuntimes.includes(runtime) && metadataRuntime !== undefined && metadataRuntime in runtimeMetadataLookup) {
+          runtimeType = runtimeMetadataLookup[metadataRuntime];
+        }
       }
       if (architecture !== undefined && architecture in architectureLookup) {
         architectureType = architectureLookup[architecture];

--- a/serverless/src/layer.ts
+++ b/serverless/src/layer.ts
@@ -10,6 +10,7 @@ export enum RuntimeType {
   JAVA,
   NODE,
   PYTHON,
+  GOLANG,
   UNSUPPORTED,
 }
 
@@ -68,6 +69,7 @@ export const agnosticRuntimes: string[] = [
 ]
 
 export const runtimeMetadataLookup: { [key: string]: RuntimeType } = {
+  "golang": RuntimeType.GOLANG
 };
 
 export const layerNameLookup: { [key in ArchitectureType]: { [key: string]: string } } = {
@@ -92,6 +94,7 @@ export const layerNameLookup: { [key in ArchitectureType]: { [key: string]: stri
     "python3.10": "Datadog-Python310",
     "python3.11": "Datadog-Python311",
     "python3.12": "Datadog-Python312",
+    "golang": "Datadog-Extension",
   },
   [ArchitectureType.ARM64]: {
     dotnet6: "dd-trace-dotnet-ARM",
@@ -111,6 +114,7 @@ export const layerNameLookup: { [key in ArchitectureType]: { [key: string]: stri
     "python3.10": "Datadog-Python310-ARM",
     "python3.11": "Datadog-Python311-ARM",
     "python3.12": "Datadog-Python312-ARM",
+    "golang": "Datadog-Extension-ARM",
   },
 };
 
@@ -239,6 +243,10 @@ export function applyLayers(
       log.debug(`Setting Java Lambda layer for ${lambda.key}`);
       lambdaLibraryLayerArn = getLambdaLibraryLayerArn(region, javaLayerVersion, lambda.runtime, lambda.architecture);
       addLayer(lambdaLibraryLayerArn, lambda);
+    }
+
+    if (lambda.runtimeType === RuntimeType.GOLANG) {
+      log.log(`Not adding a tracer layer, as there is none for golang`)
     }
   });
   return errors;

--- a/serverless/test/layer.spec.ts
+++ b/serverless/test/layer.spec.ts
@@ -13,7 +13,7 @@ import {
   getNewLayers,
 } from "../src/layer";
 
-function mockFunctionResource(runtime: string | { Ref: string }, architectures?: string[], packageType?: string) {
+function mockFunctionResource(runtime: string | { Ref: string }, architectures?: string[], packageType?: string, metadata?: { [key: string]: string } ) {
   return {
     Type: "AWS::Lambda::Function",
     Properties: {
@@ -21,6 +21,7 @@ function mockFunctionResource(runtime: string | { Ref: string }, architectures?:
       Role: "role-arn",
       Runtime: runtime,
       Architectures: architectures,
+      Metadata: metadata,
       ...(packageType && { PackageType: packageType }), // set PackageType property if available
     },
   };
@@ -33,6 +34,7 @@ function mockLambdaFunction(
   architecture: string,
   architectureType: ArchitectureType = ArchitectureType.x86_64,
   runtimeProperty?: { Ref: string },
+  metadata?: { [key: string]: string },
 ) {
   return {
     properties: {
@@ -40,6 +42,7 @@ function mockLambdaFunction(
       Runtime: runtimeProperty ?? runtime,
       Role: "role-arn",
       Architectures: [architecture],
+      Metadata: metadata,
     },
     key,
     runtimeType,
@@ -73,6 +76,10 @@ describe("findLambdas", () => {
       Python311Function: mockFunctionResource("python3.11", ["x86_64"]),
       Python312Function: mockFunctionResource("python3.12", ["x86_64"]),
       GoFunction: mockFunctionResource("go1.10", ["x86_64"]),
+      ProvidedFunctionWithoutMetadata2: mockFunctionResource("provided.al2", ["x86_64"]),
+      ProvidedFunctionWithoutMetadata2023: mockFunctionResource("provided.al2023", ["x86_64"]),
+      ProvidedFunctionWithInvalidMetadata: mockFunctionResource("provided.al2023", ["x86_64"], undefined, {"Runtime": "doesnotexist"}),
+      PythonFunctionWithMetadata: mockFunctionResource("python3.12", ["x86_64"], undefined, {"Runtime": "golang"}),
       RefFunction: mockFunctionResource({ Ref: "ValueRef" }, ["arm64"]),
     };
     const lambdas = findLambdas(resources, { ValueRef: "nodejs14.x" });
@@ -99,6 +106,10 @@ describe("findLambdas", () => {
       mockLambdaFunction("Python311Function", "python3.11", RuntimeType.PYTHON, "x86_64", ArchitectureType.x86_64),
       mockLambdaFunction("Python312Function", "python3.12", RuntimeType.PYTHON, "x86_64", ArchitectureType.x86_64),
       mockLambdaFunction("GoFunction", "go1.10", RuntimeType.UNSUPPORTED, "x86_64", ArchitectureType.x86_64),
+      mockLambdaFunction("ProvidedFunctionWithoutMetadata2", "provided.al2", RuntimeType.UNSUPPORTED, "x86_64", ArchitectureType.x86_64),
+      mockLambdaFunction("ProvidedFunctionWithoutMetadata2023", "provided.al2023", RuntimeType.UNSUPPORTED, "x86_64", ArchitectureType.x86_64),
+      mockLambdaFunction("ProvidedFunctionWithInvalidMetadata", "provided.al2023", RuntimeType.UNSUPPORTED, "x86_64", ArchitectureType.x86_64, undefined, {"Runtime": "doesnotexist"}),
+      mockLambdaFunction("PythonFunctionWithMetadata", "python3.12", RuntimeType.PYTHON, "x86_64", ArchitectureType.x86_64, undefined, {"Runtime": "golang"}),
       mockLambdaFunction("RefFunction", "nodejs14.x", RuntimeType.NODE, "arm64", ArchitectureType.ARM64, {
         Ref: "ValueRef",
       }),


### PR DESCRIPTION
### What does this PR do?

Add support for Golang! (#128)

### Motivation

I have some Golang lambdas managed with AWS SAM and would like to use the DD macro with them ;)

### Testing Guidelines

I added tests for the relevant language-specific functions (mainly `layer.ts`). Most functionality is language agnostic (and current tests mainly use python), so I added no go-specific tests here.

I also found some tests (but no matching implementation) for the `go1.10` runtime. Using that runtime is [deprecated](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtime-support-policy), so I skipped implementation for that.

### Additional Notes

It is a bit weird to detect that a lambda function is using go, as there is nothing inherent in the SAM template that identifies a lambda as "written in Go", due to it being a compiled language.

It is not possible to use the `Runtime` configuration, as it's currently being done for the other languages. `Runtime` is [now always supposed to be set to `provided.al*`](https://docs.aws.amazon.com/lambda/latest/dg/lambda-golang.html#golang-al1) for go, which is also used for other compiled runtimes (e.g. Rust). 

My approach:

* I first though about providing a macro-level configration value to set the lambda for all discovered runtimes, but this will not work with multiple lambdas with different runtimes.
* Using the `Metadata.BuildMethod` (which is often set to `go1.x` for go lambdas) is also not reliable, as this may also be a language-agnostic `makefile`.
* I did not want to "pollute" either the function tags or the env variables with a new variable that specifies the runtime.

In the end, I decided to add another `Metadata` field, `Metadata.Runtime`, that will treat the lambda as a Golang lambda. It's backwards compatible, so all current configuration will continue to use the `runtime` value if applicable, regardless of `Metadata.Runtime`.

Funny thing is: There is nothing inherent to Go about all of this. There is no Golang tracing layer anyway, like it exists for the other languages. In the end, we just add the Datadog base layer and that's it. So it would have been possible to make this completely independent of go, and just add the Database base layer whenever we see a lambda with one of the `provided.al*` runtimes. That would make it work for other compiled languages as well (e.g. Rust). I decided against it, as language support should be specific in my opinion, but this is up to debate of course.

In the end, there are two ways to proceed, and I think this is maintainer-level decision:

1. Keep the PR as it is, only officially support Go
2. Add (implicit) support for all compiled languages by removing the go-specific stuff

I set this PR to "draft", as documentation is missing. I will update this PR with documentation when the decision about the question above (and possible rework) is done.

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] :warning: This PR impacts documentation, and it has been updated (or a ticket has been logged) **=> will update docs when finalized**
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
