### PR TITLE
Move lambda tests into a folder

### DIFF
--- a/serverless/test/index.spec.ts
+++ b/serverless/test/index.spec.ts
@@ -1,50 +1,13 @@
-import { handler } from "../src/index";
 import { InputEvent } from "../src/types";
-import { FunctionProperties } from "lambda/types";
-import { getMissingStackNameErrorMsg } from "../src/lambda/lambda";
-import { getMissingLayerVersionErrorMsg } from "../src/lambda/layer";
-import { IamRoleProperties } from "../src/lambda/tracing";
-import {
-  DescribeLogGroupsRequest,
-  DescribeLogGroupsResponse,
-  DescribeSubscriptionFiltersRequest,
-  CreateLogGroupRequest,
-  PutSubscriptionFilterRequest,
-} from "aws-sdk/clients/cloudwatchlogs";
+import { FunctionProperties } from "../src/lambda/types";
 import { LogGroupDefinition } from "../src/lambda/forwarder";
+import { handler } from "../src/index";
 
-const LAMBDA_KEY = "HelloWorldFunction";
-const VERSION_REGEX =
+export const LAMBDA_KEY = "HelloWorldFunction";
+export const VERSION_REGEX =
   /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$/;
-jest.mock("aws-sdk", () => {
-  return {
-    CloudWatchLogs: jest.fn().mockImplementation((_) => {
-      return {
-        describeLogGroups: (params: DescribeLogGroupsRequest, callback?: any) => {
-          const response: DescribeLogGroupsResponse = {
-            logGroups: [{ logGroupName: `/aws/lambda/stack-name-${LAMBDA_KEY}` }],
-          };
-          return {
-            promise: jest.fn().mockImplementation(() => Promise.resolve(response)),
-          };
-        },
-        describeSubscriptionFilters: (params: DescribeSubscriptionFiltersRequest, callback?: any) => {
-          return {
-            promise: jest.fn().mockImplementation(() => Promise.resolve([])),
-          };
-        },
-        putSubscriptionFilter: (params: PutSubscriptionFilterRequest, callback?: any) => {
-          return { promise: () => Promise.resolve() };
-        },
-        createLogGroup: (params: CreateLogGroupRequest, callback?: any) => {
-          return { promise: () => Promise.resolve() };
-        },
-      };
-    }),
-  };
-});
 
-function mockInputEvent(
+export function mockInputEvent(
   params: any,
   mappings: any,
   logGroups?: LogGroupDefinition[],
@@ -129,7 +92,7 @@ function mockInputEvent(
   } as InputEvent;
 }
 
-function mockGovCloudInputEvent(params: any, mappings: any, logGroups?: LogGroupDefinition[]) {
+export function mockGovCloudInputEvent(params: any, mappings: any, logGroups?: LogGroupDefinition[]) {
   const govCloudEvent = mockInputEvent(params, mappings, logGroups);
   govCloudEvent.region = "us-gov-east-1";
   return govCloudEvent;
@@ -166,199 +129,6 @@ describe("Macro", () => {
       expect(lambdaProperties.Environment).toMatchObject({
         Variables: { DD_SITE: "datadoghq.eu" },
       });
-    });
-  });
-
-  describe("lambda layers", () => {
-    it("adds lambda layers by default", async () => {
-      const params = { nodeLayerVersion: 25 };
-      const inputEvent = mockInputEvent(params, {}); // Use default configuration
-      const output = await handler(inputEvent, {});
-      const lambdaProperties: FunctionProperties = output.fragment.Resources[LAMBDA_KEY].Properties;
-
-      // Mocked Lambda has runtime nodejs12.x, so layer name is Datadog-Node12-x, with provided version number (25) at end
-      expect(lambdaProperties.Layers).toEqual([
-        expect.stringMatching(/arn:aws:lambda:us-east-1:.*:layer:Datadog-Node12-x:25/),
-      ]);
-    });
-
-    it("macro fails when corresponding lambda layer version is not provided", async () => {
-      const params = { addExtension: false };
-      const inputEvent = mockInputEvent(params, {}); // Use default configuration, no lambda layer version provided
-      const output = await handler(inputEvent, {});
-
-      expect(output.status).toEqual("failure");
-      expect(output.errorMessage).toEqual(getMissingLayerVersionErrorMsg(LAMBDA_KEY, "Node.js", "node"));
-    });
-
-    it("add only the extension layer", async () => {
-      const params = { addLayers: false, addExtension: true, extensionLayerVersion: 6, apiKey: "abc123" };
-      const inputEvent = mockInputEvent(params, {});
-      const output = await handler(inputEvent, {});
-      const lambdaProperties: FunctionProperties = output.fragment.Resources[LAMBDA_KEY].Properties;
-
-      // Mocked Lambda has the addExtension parameter to true and extensionLayerVersion to 6.
-      expect(lambdaProperties.Layers).toEqual([
-        expect.stringMatching(/arn:aws:lambda:us-east-1:.*:layer:Datadog-Extension:6/),
-      ]);
-    });
-
-    it("add only the extension layer by only setting the extension layer version", async () => {
-      const params = { addLayers: false, extensionLayerVersion: 6, apiKey: "abc123" };
-      const inputEvent = mockInputEvent(params, {});
-      const output = await handler(inputEvent, {});
-      const lambdaProperties: FunctionProperties = output.fragment.Resources[LAMBDA_KEY].Properties;
-
-      // Mocked Lambda has the addExtension parameter to true and extensionLayerVersion to 6.
-      expect(lambdaProperties.Layers).toEqual([
-        expect.stringMatching(/arn:aws:lambda:us-east-1:.*:layer:Datadog-Extension:6/),
-      ]);
-    });
-
-    it("skips adding lambda layers when addLayers is false", async () => {
-      const params = { addLayers: false };
-      const inputEvent = mockInputEvent(params, {});
-      const output = await handler(inputEvent, {});
-      const lambdaProperties: FunctionProperties = output.fragment.Resources[LAMBDA_KEY].Properties;
-
-      expect(lambdaProperties.Layers).toBeUndefined();
-    });
-
-    it("uses the GovCloud layer when a GovCloud region is detected", async () => {
-      const params = { nodeLayerVersion: 25 };
-      const inputEvent = mockGovCloudInputEvent(params, {});
-      const output = await handler(inputEvent, {});
-      const lambdaProperties: FunctionProperties = output.fragment.Resources[LAMBDA_KEY].Properties;
-
-      expect(lambdaProperties.Layers).toEqual([
-        expect.stringMatching(/arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Node12-x:25/),
-      ]);
-    });
-
-    it("Excluding a lambda function from being instrumented", async () => {
-      const params = { exclude: [LAMBDA_KEY], nodeLayerVersion: 32, extensionLayerVersion: 32, apiKey: "testtest" };
-      const inputEvent = mockInputEvent(params, {}); // Use default configuration
-      const output = await handler(inputEvent, {});
-      const lambdaProperties: FunctionProperties = output.fragment.Resources[LAMBDA_KEY].Properties;
-
-      expect(lambdaProperties.Layers).toBeUndefined();
-      expect(lambdaProperties.Handler).toBe("app.handler");
-    });
-  });
-
-  describe("tracing", () => {
-    it("skips adding tracing when enableXrayTracing is false", async () => {
-      const params = { enableXrayTracing: false };
-      const inputEvent = mockInputEvent(params, {});
-      const output = await handler(inputEvent, {});
-      const iamRole: IamRoleProperties = output.fragment.Resources[`${LAMBDA_KEY}Role`].Properties;
-      const lambdaProperties: FunctionProperties = output.fragment.Resources[LAMBDA_KEY].Properties;
-
-      expect(lambdaProperties.TracingConfig).toBeUndefined();
-      expect(iamRole.Policies).toBeUndefined();
-    });
-  });
-
-  describe("CloudWatch subscriptions", () => {
-    it("adds subscription filters when forwarder is provided", async () => {
-      const params = {
-        forwarderArn: "forwarder-arn",
-        stackName: "stack-name",
-        nodeLayerVersion: 25,
-        addExtension: false,
-      };
-      const inputEvent = mockInputEvent(params, {});
-      await handler(inputEvent, {});
-
-      // Mocked response includes implicitly created log group, should not create log group
-      // expect(cloudWatchLogs.createLogGroup).not.toHaveBeenCalled();
-      // expect(cloudWatchLogs.putSubscriptionFilter).toHaveBeenCalled();
-    });
-
-    it("macro fails when forwarder is provided & at least one lambda has a dynamically generated name, but no stack name is given", async () => {
-      const params = { forwarderArn: "forwarder-arn", nodeLayerVersion: 25 };
-      const inputEvent = mockInputEvent(params, {});
-      const output = await handler(inputEvent, {});
-
-      expect(output.status).toEqual("failure");
-      expect(output.errorMessage).toEqual(getMissingStackNameErrorMsg([LAMBDA_KEY]));
-    });
-  });
-
-  describe("tags", () => {
-    it("only adds macro version tag when neither 'service' nor 'env' are provided", async () => {
-      const params = { nodeLayerVersion: 25 };
-      const inputEvent = mockInputEvent(params, {});
-      const output = await handler(inputEvent, {});
-      const lambdaProperties: FunctionProperties = output.fragment.Resources[LAMBDA_KEY].Properties;
-
-      expect(lambdaProperties.Tags).toEqual([{ Key: "dd_sls_macro", Value: expect.stringMatching(VERSION_REGEX) }]);
-    });
-
-    it("only adds cdk created tag when CDKMetadata is present", async () => {
-      const params = { nodeLayerVersion: 25 };
-      const inputEvent = mockInputEvent(params, {}, undefined, true);
-      const output = await handler(inputEvent, {});
-      const lambdaProperties: FunctionProperties = output.fragment.Resources[LAMBDA_KEY].Properties;
-
-      expect(lambdaProperties.Tags).toEqual([
-        { Key: "dd_sls_macro", Value: expect.stringMatching(VERSION_REGEX) },
-        { Key: "dd_sls_macro_by", Value: "CDK" },
-      ]);
-    });
-
-    it("only adds SAM created tag when lambda:createdBy:SAM tag is present", async () => {
-      const params = { nodeLayerVersion: 25 };
-      const inputEvent = mockInputEvent(params, {}, undefined, false, true);
-      const output = await handler(inputEvent, {});
-      const lambdaProperties: FunctionProperties = output.fragment.Resources[LAMBDA_KEY].Properties;
-
-      expect(lambdaProperties.Tags).toEqual([
-        { Key: "lambda:createdBy", Value: "SAM" },
-        { Key: "dd_sls_macro", Value: expect.stringMatching(VERSION_REGEX) },
-        { Key: "dd_sls_macro_by", Value: "SAM" },
-      ]);
-    });
-
-    it("adds tags if tag params are provided and forwarderArn is set", async () => {
-      const params = {
-        service: "my-service",
-        env: "test",
-        version: "1",
-        tags: "team:avengers,project:marvel",
-        forwarderArn: "forwarder-arn",
-        stackName: "stack-name",
-        nodeLayerVersion: 25,
-        addExtension: false,
-      };
-      const inputEvent = mockInputEvent(params, {});
-      const output = await handler(inputEvent, {});
-      const lambdaProperties: FunctionProperties = output.fragment.Resources[LAMBDA_KEY].Properties;
-
-      expect(lambdaProperties.Tags).toEqual([
-        { Key: "service", Value: "my-service" },
-        { Key: "env", Value: "test" },
-        { Key: "version", Value: "1" },
-        { Key: "team", Value: "avengers" },
-        { Key: "project", Value: "marvel" },
-        { Key: "dd_sls_macro", Value: expect.stringMatching(VERSION_REGEX) },
-      ]);
-    });
-
-    it("doesn't add tags if tags params are provided but forwarderArn is not set", async () => {
-      const params = {
-        service: "my-service",
-        env: "test",
-        version: "1",
-        tags: "team:avengers,project:marvel",
-        nodeLayerVersion: 25,
-        addExtension: false,
-      };
-      const inputEvent = mockInputEvent(params, {});
-      const output = await handler(inputEvent, {});
-      const lambdaProperties: FunctionProperties = output.fragment.Resources[LAMBDA_KEY].Properties;
-
-      expect(lambdaProperties.Tags).toEqual([{ Key: "dd_sls_macro", Value: expect.stringMatching(VERSION_REGEX) }]);
     });
   });
 });

--- a/serverless/test/lambda/env.spec.ts
+++ b/serverless/test/lambda/env.spec.ts
@@ -6,8 +6,8 @@ import {
   setEnvConfiguration,
   validateParameters,
   checkForMultipleApiKeys,
-} from "../src/lambda/env";
-import { ArchitectureType, LambdaFunction, RuntimeType } from "../src/lambda/layer";
+} from "../../src/lambda/env";
+import { ArchitectureType, LambdaFunction, RuntimeType } from "../../src/lambda/layer";
 
 describe("getConfig", () => {
   it("correctly parses parameters from Mappings", () => {

--- a/serverless/test/lambda/forwarder.spec.ts
+++ b/serverless/test/lambda/forwarder.spec.ts
@@ -7,8 +7,8 @@ import {
   addCloudWatchForwarderSubscriptions,
   LogGroupDefinition,
   SUBSCRIPTION_FILTER_NAME,
-} from "../src/lambda/forwarder";
-import { LambdaFunction, RuntimeType } from "../src/lambda/layer";
+} from "../../src/lambda/forwarder";
+import { LambdaFunction, RuntimeType } from "../../src/lambda/layer";
 
 function mockCloudWatchLogs(
   logGroups: Record<

--- a/serverless/test/lambda/git.spec.ts
+++ b/serverless/test/lambda/git.spec.ts
@@ -1,4 +1,4 @@
-import { filterSensitiveInfoFromRepository, getGitTagsFromParam } from "../src/lambda/git";
+import { filterSensitiveInfoFromRepository, getGitTagsFromParam } from "../../src/lambda/git";
 
 describe("getGitTagsFromParam", () => {
   it("produces SCI tags with username@domain", () => {

--- a/serverless/test/lambda/lambda.spec.ts
+++ b/serverless/test/lambda/lambda.spec.ts
@@ -1,0 +1,236 @@
+import { handler } from "../../src/index";
+import { getMissingStackNameErrorMsg } from "../../src/lambda/lambda";
+import { getMissingLayerVersionErrorMsg } from "../../src/lambda/layer";
+import { IamRoleProperties } from "../../src/lambda/tracing";
+import { FunctionProperties } from "../../src/lambda/types";
+import { mockInputEvent, LAMBDA_KEY, mockGovCloudInputEvent, VERSION_REGEX } from "../index.spec";
+import {
+  DescribeLogGroupsRequest,
+  DescribeLogGroupsResponse,
+  DescribeSubscriptionFiltersRequest,
+  CreateLogGroupRequest,
+  PutSubscriptionFilterRequest,
+} from "aws-sdk/clients/cloudwatchlogs";
+
+jest.mock("aws-sdk", () => {
+  return {
+    CloudWatchLogs: jest.fn().mockImplementation((_) => {
+      return {
+        describeLogGroups: (params: DescribeLogGroupsRequest, callback?: any) => {
+          const response: DescribeLogGroupsResponse = {
+            logGroups: [{ logGroupName: `/aws/lambda/stack-name-${LAMBDA_KEY}` }],
+          };
+          return {
+            promise: jest.fn().mockImplementation(() => Promise.resolve(response)),
+          };
+        },
+        describeSubscriptionFilters: (params: DescribeSubscriptionFiltersRequest, callback?: any) => {
+          return {
+            promise: jest.fn().mockImplementation(() => Promise.resolve([])),
+          };
+        },
+        putSubscriptionFilter: (params: PutSubscriptionFilterRequest, callback?: any) => {
+          return { promise: () => Promise.resolve() };
+        },
+        createLogGroup: (params: CreateLogGroupRequest, callback?: any) => {
+          return { promise: () => Promise.resolve() };
+        },
+      };
+    }),
+  };
+});
+
+describe("Lambda", () => {
+  describe("lambda layers", () => {
+    it("adds lambda layers by default", async () => {
+      const params = { nodeLayerVersion: 25 };
+      const inputEvent = mockInputEvent(params, {}); // Use default configuration
+      const output = await handler(inputEvent, {});
+      const lambdaProperties: FunctionProperties = output.fragment.Resources[LAMBDA_KEY].Properties;
+
+      // Mocked Lambda has runtime nodejs12.x, so layer name is Datadog-Node12-x, with provided version number (25) at end
+      expect(lambdaProperties.Layers).toEqual([
+        expect.stringMatching(/arn:aws:lambda:us-east-1:.*:layer:Datadog-Node12-x:25/),
+      ]);
+    });
+
+    it("macro fails when corresponding lambda layer version is not provided", async () => {
+      const params = { addExtension: false };
+      const inputEvent = mockInputEvent(params, {}); // Use default configuration, no lambda layer version provided
+      const output = await handler(inputEvent, {});
+
+      expect(output.status).toEqual("failure");
+      expect(output.errorMessage).toEqual(getMissingLayerVersionErrorMsg(LAMBDA_KEY, "Node.js", "node"));
+    });
+
+    it("add only the extension layer", async () => {
+      const params = { addLayers: false, addExtension: true, extensionLayerVersion: 6, apiKey: "abc123" };
+      const inputEvent = mockInputEvent(params, {});
+      const output = await handler(inputEvent, {});
+      const lambdaProperties: FunctionProperties = output.fragment.Resources[LAMBDA_KEY].Properties;
+
+      // Mocked Lambda has the addExtension parameter to true and extensionLayerVersion to 6.
+      expect(lambdaProperties.Layers).toEqual([
+        expect.stringMatching(/arn:aws:lambda:us-east-1:.*:layer:Datadog-Extension:6/),
+      ]);
+    });
+
+    it("add only the extension layer by only setting the extension layer version", async () => {
+      const params = { addLayers: false, extensionLayerVersion: 6, apiKey: "abc123" };
+      const inputEvent = mockInputEvent(params, {});
+      const output = await handler(inputEvent, {});
+      const lambdaProperties: FunctionProperties = output.fragment.Resources[LAMBDA_KEY].Properties;
+
+      // Mocked Lambda has the addExtension parameter to true and extensionLayerVersion to 6.
+      expect(lambdaProperties.Layers).toEqual([
+        expect.stringMatching(/arn:aws:lambda:us-east-1:.*:layer:Datadog-Extension:6/),
+      ]);
+    });
+
+    it("skips adding lambda layers when addLayers is false", async () => {
+      const params = { addLayers: false };
+      const inputEvent = mockInputEvent(params, {});
+      const output = await handler(inputEvent, {});
+      const lambdaProperties: FunctionProperties = output.fragment.Resources[LAMBDA_KEY].Properties;
+
+      expect(lambdaProperties.Layers).toBeUndefined();
+    });
+
+    it("uses the GovCloud layer when a GovCloud region is detected", async () => {
+      const params = { nodeLayerVersion: 25 };
+      const inputEvent = mockGovCloudInputEvent(params, {});
+      const output = await handler(inputEvent, {});
+      const lambdaProperties: FunctionProperties = output.fragment.Resources[LAMBDA_KEY].Properties;
+
+      expect(lambdaProperties.Layers).toEqual([
+        expect.stringMatching(/arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Node12-x:25/),
+      ]);
+    });
+
+    it("Excluding a lambda function from being instrumented", async () => {
+      const params = { exclude: [LAMBDA_KEY], nodeLayerVersion: 32, extensionLayerVersion: 32, apiKey: "testtest" };
+      const inputEvent = mockInputEvent(params, {}); // Use default configuration
+      const output = await handler(inputEvent, {});
+      const lambdaProperties: FunctionProperties = output.fragment.Resources[LAMBDA_KEY].Properties;
+
+      expect(lambdaProperties.Layers).toBeUndefined();
+      expect(lambdaProperties.Handler).toBe("app.handler");
+    });
+  });
+
+  describe("tracing", () => {
+    it("skips adding tracing when enableXrayTracing is false", async () => {
+      const params = { enableXrayTracing: false };
+      const inputEvent = mockInputEvent(params, {});
+      const output = await handler(inputEvent, {});
+      const iamRole: IamRoleProperties = output.fragment.Resources[`${LAMBDA_KEY}Role`].Properties;
+      const lambdaProperties: FunctionProperties = output.fragment.Resources[LAMBDA_KEY].Properties;
+
+      expect(lambdaProperties.TracingConfig).toBeUndefined();
+      expect(iamRole.Policies).toBeUndefined();
+    });
+  });
+
+  describe("CloudWatch subscriptions", () => {
+    it("adds subscription filters when forwarder is provided", async () => {
+      const params = {
+        forwarderArn: "forwarder-arn",
+        stackName: "stack-name",
+        nodeLayerVersion: 25,
+        addExtension: false,
+      };
+      const inputEvent = mockInputEvent(params, {});
+      await handler(inputEvent, {});
+
+      // Mocked response includes implicitly created log group, should not create log group
+      // expect(cloudWatchLogs.createLogGroup).not.toHaveBeenCalled();
+      // expect(cloudWatchLogs.putSubscriptionFilter).toHaveBeenCalled();
+    });
+
+    it("macro fails when forwarder is provided & at least one lambda has a dynamically generated name, but no stack name is given", async () => {
+      const params = { forwarderArn: "forwarder-arn", nodeLayerVersion: 25 };
+      const inputEvent = mockInputEvent(params, {});
+      const output = await handler(inputEvent, {});
+
+      expect(output.status).toEqual("failure");
+      expect(output.errorMessage).toEqual(getMissingStackNameErrorMsg([LAMBDA_KEY]));
+    });
+  });
+
+  describe("tags", () => {
+    it("only adds macro version tag when neither 'service' nor 'env' are provided", async () => {
+      const params = { nodeLayerVersion: 25 };
+      const inputEvent = mockInputEvent(params, {});
+      const output = await handler(inputEvent, {});
+      const lambdaProperties: FunctionProperties = output.fragment.Resources[LAMBDA_KEY].Properties;
+
+      expect(lambdaProperties.Tags).toEqual([{ Key: "dd_sls_macro", Value: expect.stringMatching(VERSION_REGEX) }]);
+    });
+
+    it("only adds cdk created tag when CDKMetadata is present", async () => {
+      const params = { nodeLayerVersion: 25 };
+      const inputEvent = mockInputEvent(params, {}, undefined, true);
+      const output = await handler(inputEvent, {});
+      const lambdaProperties: FunctionProperties = output.fragment.Resources[LAMBDA_KEY].Properties;
+
+      expect(lambdaProperties.Tags).toEqual([
+        { Key: "dd_sls_macro", Value: expect.stringMatching(VERSION_REGEX) },
+        { Key: "dd_sls_macro_by", Value: "CDK" },
+      ]);
+    });
+
+    it("only adds SAM created tag when lambda:createdBy:SAM tag is present", async () => {
+      const params = { nodeLayerVersion: 25 };
+      const inputEvent = mockInputEvent(params, {}, undefined, false, true);
+      const output = await handler(inputEvent, {});
+      const lambdaProperties: FunctionProperties = output.fragment.Resources[LAMBDA_KEY].Properties;
+
+      expect(lambdaProperties.Tags).toEqual([
+        { Key: "lambda:createdBy", Value: "SAM" },
+        { Key: "dd_sls_macro", Value: expect.stringMatching(VERSION_REGEX) },
+        { Key: "dd_sls_macro_by", Value: "SAM" },
+      ]);
+    });
+
+    it("adds tags if tag params are provided and forwarderArn is set", async () => {
+      const params = {
+        service: "my-service",
+        env: "test",
+        version: "1",
+        tags: "team:avengers,project:marvel",
+        forwarderArn: "forwarder-arn",
+        stackName: "stack-name",
+        nodeLayerVersion: 25,
+        addExtension: false,
+      };
+      const inputEvent = mockInputEvent(params, {});
+      const output = await handler(inputEvent, {});
+      const lambdaProperties: FunctionProperties = output.fragment.Resources[LAMBDA_KEY].Properties;
+
+      expect(lambdaProperties.Tags).toEqual([
+        { Key: "service", Value: "my-service" },
+        { Key: "env", Value: "test" },
+        { Key: "version", Value: "1" },
+        { Key: "team", Value: "avengers" },
+        { Key: "project", Value: "marvel" },
+        { Key: "dd_sls_macro", Value: expect.stringMatching(VERSION_REGEX) },
+      ]);
+    });
+
+    it("doesn't add tags if tags params are provided but forwarderArn is not set", async () => {
+      const params = {
+        service: "my-service",
+        env: "test",
+        version: "1",
+        tags: "team:avengers,project:marvel",
+        nodeLayerVersion: 25,
+        addExtension: false,
+      };
+      const inputEvent = mockInputEvent(params, {});
+      const output = await handler(inputEvent, {});
+      const lambdaProperties: FunctionProperties = output.fragment.Resources[LAMBDA_KEY].Properties;
+
+      expect(lambdaProperties.Tags).toEqual([{ Key: "dd_sls_macro", Value: expect.stringMatching(VERSION_REGEX) }]);
+    });
+  });
+});

--- a/serverless/test/lambda/layer.spec.ts
+++ b/serverless/test/lambda/layer.spec.ts
@@ -11,7 +11,7 @@ import {
   getExtensionLayerArn,
   ArchitectureType,
   getNewLayers,
-} from "../src/lambda/layer";
+} from "../../src/lambda/layer";
 
 function mockFunctionResource(runtime: string | { Ref: string }, architectures?: string[], packageType?: string) {
   return {

--- a/serverless/test/lambda/redirect.spec.ts
+++ b/serverless/test/lambda/redirect.spec.ts
@@ -4,8 +4,8 @@ import {
   JS_HANDLER,
   PYTHON_HANDLER,
   DD_HANDLER_ENV_VAR,
-} from "../src/lambda/redirect";
-import { LambdaFunction, RuntimeType } from "../src/lambda/layer";
+} from "../../src/lambda/redirect";
+import { LambdaFunction, RuntimeType } from "../../src/lambda/layer";
 
 function mockLambdaFunction(key: string, runtime: string, runtimeType: RuntimeType) {
   return {

--- a/serverless/test/lambda/tags.spec.ts
+++ b/serverless/test/lambda/tags.spec.ts
@@ -1,6 +1,6 @@
-import { defaultConfiguration, getConfigFromEnvVars } from "../src/lambda/env";
-import { RuntimeType, LambdaFunction } from "../src/lambda/layer";
-import { addDDTags, addMacroTag, addCDKTag, addSAMTag } from "../src/lambda/tags";
+import { defaultConfiguration, getConfigFromEnvVars } from "../../src/lambda/env";
+import { RuntimeType, LambdaFunction } from "../../src/lambda/layer";
+import { addDDTags, addMacroTag, addCDKTag, addSAMTag } from "../../src/lambda/tags";
 
 function mockLambdaFunction(tags: { Key: string; Value: string }[]) {
   return {

--- a/serverless/test/lambda/tracing.spec.ts
+++ b/serverless/test/lambda/tracing.spec.ts
@@ -1,5 +1,5 @@
-import { enableTracing, TracingMode, IamRoleProperties, MissingIamRoleError } from "../src/lambda/tracing";
-import { ArchitectureType, LambdaFunction, RuntimeType } from "../src/lambda/layer";
+import { enableTracing, TracingMode, IamRoleProperties, MissingIamRoleError } from "../../src/lambda/tracing";
+import { ArchitectureType, LambdaFunction, RuntimeType } from "../../src/lambda/layer";
 
 function mockLambdaFunction() {
   return {


### PR DESCRIPTION
### Context of this PR series

Right now the Datadog Serverless CloudFormation Macro only supports instrumenting Lambda functions. This series of PRs makes it also support instrumenting Step Functions.

Instead of merging every PR into main branch, I'm going to merge them into a feature branch `yiming.luo/step-function` to:
1. respect the holiday production freeze
2. avoid releasing partial support for step functions

### What does this PR do?

Move tests node for Lambda to a `lambda` folder. Later I will create a `step_function` folder, so Lambda and Step Function code and tests will be separate and more clear.

<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

Run `npm test` to run existing tests. They still pass.

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
