### PR TITLE
[Step Function][DRAFT] Set up logging

### DIFF
--- a/serverless/src/index.ts
+++ b/serverless/src/index.ts
@@ -1,5 +1,6 @@
 import { getConfigFromCfnMappings, getConfigFromCfnParams, validateParameters, Configuration } from "./lambda/env";
 import { instrumentLambdas } from "./lambda/lambda";
+import { instrumentStateMachines } from "./step_function/step_function";
 import { InputEvent, OutputEvent, SUCCESS, FAILURE } from "./types";
 import log from "loglevel";
 
@@ -35,6 +36,11 @@ export const handler = async (event: InputEvent, _: any): Promise<OutputEvent> =
     const lambdaOutput = await instrumentLambdas(event, config);
     if (lambdaOutput.status === FAILURE) {
       return lambdaOutput;
+    }
+
+    const stepFunctionOutput = await instrumentStateMachines(event);
+    if (stepFunctionOutput.status === FAILURE) {
+      return stepFunctionOutput;
     }
 
     return {

--- a/serverless/src/step_function/env.ts
+++ b/serverless/src/step_function/env.ts
@@ -1,0 +1,50 @@
+import log from "loglevel";
+
+export interface Configuration {
+  // When set, it will be added to the state machine's log group name.
+  env?: string;
+}
+
+const envEnvVar = "DD_ENV";
+
+// Same interface as Configuration above, except all parameters are optional, since user does
+// not have to provide the values (in which case we will use the default configuration below).
+interface CfnParams extends Partial<Configuration> {}
+
+export const defaultConfiguration: Configuration = {};
+
+/**
+ * Returns the default configuration with any values overwritten by environment variables.
+ */
+export function getConfigFromEnvVars(): Configuration {
+  const config: Configuration = {
+    ...defaultConfiguration,
+  };
+
+  if (envEnvVar in process.env) {
+    config.env = process.env[envEnvVar];
+  }
+
+  return config;
+}
+
+/**
+ * Takes a set of parameters from the CloudFormation template. This could come from either
+ * the Mappings section of the template, or directly from the Parameters under the transform/macro
+ * as the 'params' property under the original InputEvent to the handler in src/index.ts
+ *
+ * Uses these parameters as the Datadog configuration, and for values that are required in the
+ * configuration but not provided in the parameters, uses the default values from
+ * the defaultConfiguration above.
+ */
+export function getConfigFromCfnParams(params: CfnParams) {
+  let datadogConfig = params as Partial<Configuration> | undefined;
+  if (datadogConfig === undefined) {
+    log.debug("No Datadog config found, using the default config");
+    datadogConfig = {};
+  }
+  return {
+    ...getConfigFromEnvVars(),
+    ...datadogConfig,
+  };
+}

--- a/serverless/src/step_function/log.ts
+++ b/serverless/src/step_function/log.ts
@@ -1,0 +1,146 @@
+import { Resources } from "../types";
+import log from "loglevel";
+import { StateMachine } from "step_function/types";
+
+const unsupportedCaseErrorMessage =
+  "Step Function Instrumentation is not supported. \
+Please open a feature request in https://github.com/DataDog/datadog-cdk-constructs.";
+
+const FN_SUB = "Fn::Sub";
+const FN_GET_ATT = "Fn::GetAtt";
+
+/**
+ * Set up logging for the given state machine:
+ * 1. Set log level to ALL
+ * 2. Set includeExecutionData to true
+ * 3. Create a destination log group (if not set already)
+ * 4. Add permissions to the state machine role to log to CloudWatch Logs
+ */
+export function setUpLogging(resources: Resources, stateMachine: StateMachine): void {
+  log.debug(`Setting up logging`);
+  if (!stateMachine.properties.LoggingConfiguration) {
+    stateMachine.properties.LoggingConfiguration = {};
+  }
+
+  const logConfig = stateMachine.properties.LoggingConfiguration;
+
+  logConfig.Level = "ALL";
+  logConfig.IncludeExecutionData = true;
+  if (!logConfig.Destinations) {
+    log.debug(`Log destination not found, creating one`);
+    const logGroupKey = createLogGroup(resources, stateMachine);
+    logConfig.Destinations = [
+      {
+        CloudWatchLogsLogGroup: {
+          LogGroupArn: {
+            "Fn::GetAtt": [logGroupKey, "Arn"],
+          },
+        },
+      },
+    ];
+  } else {
+    log.debug(`Log destination already exists, skipping creating one`);
+  }
+}
+
+function createLogGroup(resources: Resources, stateMachine: StateMachine): string {
+  const logGroupKey = `${stateMachine.resourceKey}LogGroup`;
+  resources[logGroupKey] = {
+    Type: "AWS::Logs::LogGroup",
+    Properties: {
+      LogGroupName: buildLogGroupName(stateMachine, undefined),
+      RetentionInDays: 7,
+    },
+  };
+
+  let role;
+  if (stateMachine.properties.RoleArn) {
+    log.debug(`A role is already defined. Parsing its resource key from the roleArn.`);
+    const roleArn = stateMachine.properties.RoleArn;
+
+    if (typeof roleArn !== "object") {
+      throw new Error(`RoleArn is not an object. ${unsupportedCaseErrorMessage}`);
+    }
+
+    let roleKey;
+    if (roleArn[FN_GET_ATT]) {
+      // e.g.
+      //   Fn::GetAtt: [MyStateMachineRole, "Arn"]
+      roleKey = roleArn[FN_GET_ATT][0];
+    } else if (roleArn[FN_SUB]) {
+      // e.g.
+      //   Fn::Sub: ${StatesExecutionRole.Arn}
+      const arnMatch = roleArn[FN_SUB].match(/^\${(.*)\.Arn}$/);
+      if (arnMatch) {
+        roleKey = arnMatch[1];
+      } else {
+        throw new Error(`Unsupported Fn::Sub format: ${roleArn[FN_SUB]}. ${unsupportedCaseErrorMessage}`);
+      }
+    } else {
+      throw new Error(`Unsupported RoleArn format: ${roleArn}. ${unsupportedCaseErrorMessage}`);
+    }
+    log.debug(`Found State Machine role Key: ${roleKey}`);
+    role = resources[roleKey];
+  } else {
+    log.debug(`No role is defined. Creating one.`);
+    const roleKey = `${stateMachine.resourceKey}Role`;
+    role = {
+      Type: "AWS::IAM::Role",
+      Properties: {
+        AssumeRolePolicyDocument: {
+          Version: "2012-10-17",
+          Statement: [
+            {
+              Effect: "Allow",
+              Principal: {
+                Service: "states.amazonaws.com",
+              },
+              Action: "sts:AssumeRole",
+            },
+          ],
+        },
+        Policies: [],
+      },
+    };
+    resources[roleKey] = role;
+  }
+
+  log.debug(`Add a policy to the role to grant permissions to the log group`);
+  if (!role.Properties.Policies) {
+    role.Properties.Policies = [];
+  }
+  role.Properties.Policies.push({
+    PolicyName: `${stateMachine.resourceKey}LogPolicy`,
+    PolicyDocument: {
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Action: [
+            "logs:CreateLogDelivery",
+            "logs:CreateLogStream",
+            "logs:GetLogDelivery",
+            "logs:UpdateLogDelivery",
+            "logs:DeleteLogDelivery",
+            "logs:ListLogDeliveries",
+            "logs:PutLogEvents",
+            "logs:PutResourcePolicy",
+            "logs:DescribeResourcePolicies",
+            "logs:DescribeLogGroups",
+          ],
+          Resource: "*",
+        },
+      ],
+    },
+  });
+  return logGroupKey;
+}
+
+/**
+ * Builds log group name for a state machine.
+ * @returns log group name like "/aws/vendedlogs/states/MyStateMachine-Logs" (without env)
+ *                           or "/aws/vendedlogs/states/MyStateMachine-Logs-dev" (with env)
+ */
+export const buildLogGroupName = (stateMachine: StateMachine, env: string | undefined): string => {
+  return `/aws/vendedlogs/states/${stateMachine.resourceKey}-Logs${env !== undefined ? "-" + env : ""}`;
+};

--- a/serverless/src/step_function/step_function.ts
+++ b/serverless/src/step_function/step_function.ts
@@ -1,0 +1,45 @@
+import { InputEvent, OutputEvent, SUCCESS, Resources } from "../types";
+import log from "loglevel";
+import { StateMachine, StateMachineProperties } from "../../src/step_function/types";
+import { setUpLogging } from "../../src/step_function/log";
+
+const STATE_MACHINE_RESOURCE_TYPE = "AWS::StepFunctions::StateMachine";
+
+export async function instrumentStateMachines(event: InputEvent): Promise<OutputEvent> {
+  const fragment = event.fragment;
+  const resources = fragment.Resources;
+
+  const stateMachines = findStateMachines(resources);
+  for (const stateMachine of stateMachines) {
+    instrumentStateMachine(resources, stateMachine);
+  }
+
+  return {
+    requestId: event.requestId,
+    status: SUCCESS,
+    fragment,
+  };
+}
+
+function instrumentStateMachine(resources: Resources, stateMachine: StateMachine): void {
+  log.debug(`Instrumenting State Machine ${stateMachine.resourceKey}`);
+  setUpLogging(resources, stateMachine);
+}
+
+export function findStateMachines(resources: Resources): StateMachine[] {
+  return Object.entries(resources)
+    .map(([key, resource]) => {
+      if (resource.Type !== STATE_MACHINE_RESOURCE_TYPE) {
+        log.debug(`Resource ${key} is not a State Machine, skipping...`);
+        return;
+      }
+
+      const properties: StateMachineProperties = resource.Properties;
+
+      return {
+        properties: properties,
+        resourceKey: key,
+      } as StateMachine;
+    })
+    .filter((resource) => resource !== undefined) as StateMachine[];
+}

--- a/serverless/src/step_function/types.ts
+++ b/serverless/src/step_function/types.ts
@@ -1,0 +1,27 @@
+export interface StateMachine {
+  properties: StateMachineProperties;
+  resourceKey: string;
+}
+
+export interface StateMachineProperties {
+  LoggingConfiguration?: LoggingConfiguration;
+  RoleArn?: string | { [key: string]: any };
+}
+
+export interface LoggingConfiguration {
+  Destinations?: LogDestination[];
+  IncludeExecutionData?: boolean;
+  Level?: string;
+}
+
+export interface LogDestination {
+  CloudWatchLogsLogGroup: CloudWatchLogsLogGroup;
+}
+
+export interface CloudWatchLogsLogGroup {
+  LogGroupArn:
+    | string
+    | {
+        "Fn::GetAtt": string[];
+      };
+}

--- a/serverless/test/step_function/helper.ts
+++ b/serverless/test/step_function/helper.ts
@@ -1,0 +1,20 @@
+export function getEmptyStateMachineRole() {
+  return {
+    Type: "AWS::IAM::Role",
+    Properties: {
+      AssumeRolePolicyDocument: {
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Effect: "Allow",
+            Principal: {
+              Service: "states.amazonaws.com",
+            },
+            Action: "sts:AssumeRole",
+          },
+        ],
+      },
+      Policies: [],
+    },
+  };
+}

--- a/serverless/test/step_function/log.spec.ts
+++ b/serverless/test/step_function/log.spec.ts
@@ -1,0 +1,137 @@
+import { setUpLogging, buildLogGroupName } from "../../src/step_function/log";
+import { Resources } from "types";
+import { StateMachine, LoggingConfiguration, LogDestination } from "../../src/step_function/types";
+import { getEmptyStateMachineRole } from "../../test/step_function/helper";
+
+const expectedActionsForRole = [
+  "logs:CreateLogDelivery",
+  "logs:CreateLogStream",
+  "logs:GetLogDelivery",
+  "logs:UpdateLogDelivery",
+  "logs:DeleteLogDelivery",
+  "logs:ListLogDeliveries",
+  "logs:PutLogEvents",
+  "logs:PutResourcePolicy",
+  "logs:DescribeResourcePolicies",
+  "logs:DescribeLogGroups",
+];
+
+describe("setUpLogging", () => {
+  let resources: Resources;
+  let stateMachine: StateMachine;
+
+  beforeEach(() => {
+    resources = {};
+    stateMachine = {
+      resourceKey: "MyStateMachine",
+      properties: {},
+    } as StateMachine;
+  });
+
+  it("sets up logging configuration if not present", () => {
+    setUpLogging(resources, stateMachine);
+
+    expect(stateMachine.properties.LoggingConfiguration).toBeDefined();
+    const logConfig = stateMachine.properties.LoggingConfiguration as LoggingConfiguration;
+    expect(logConfig.Level).toBe("ALL");
+    expect(logConfig.IncludeExecutionData).toBe(true);
+    expect(logConfig.Destinations).toBeDefined();
+    const dest = logConfig.Destinations as LogDestination[];
+    expect(dest.length).toBe(1);
+  });
+
+  it("updates existing logging configuration", () => {
+    stateMachine.properties.LoggingConfiguration = {
+      Level: "ERROR",
+      IncludeExecutionData: false,
+      Destinations: [
+        {
+          CloudWatchLogsLogGroup: {
+            LogGroupArn: "existing-log-group-arn",
+          },
+        },
+      ],
+    };
+
+    setUpLogging(resources, stateMachine);
+
+    expect(stateMachine.properties.LoggingConfiguration).toBeDefined();
+    const logConfig = stateMachine.properties.LoggingConfiguration as LoggingConfiguration;
+    expect(logConfig.Level).toBe("ALL");
+    expect(logConfig.IncludeExecutionData).toBe(true);
+    expect(logConfig.Destinations).toBeDefined();
+    const dest = logConfig.Destinations as LogDestination[];
+    expect(dest.length).toBe(1);
+    expect(dest[0].CloudWatchLogsLogGroup.LogGroupArn).toBe("existing-log-group-arn");
+  });
+
+  it("creates a log group if not present", () => {
+    setUpLogging(resources, stateMachine);
+
+    expect(resources["MyStateMachineLogGroup"]).toStrictEqual({
+      Type: "AWS::Logs::LogGroup",
+      Properties: {
+        LogGroupName: "/aws/vendedlogs/states/MyStateMachine-Logs",
+        RetentionInDays: 7,
+      },
+    });
+  });
+
+  it("creates a role if not present", () => {
+    setUpLogging(resources, stateMachine);
+
+    expect(resources["MyStateMachineRole"]).toBeDefined();
+    const role = resources["MyStateMachineRole"];
+    expect(role.Type).toBe("AWS::IAM::Role");
+    expect(role.Properties.Policies).toBeDefined();
+    expect(role.Properties.Policies[0].PolicyDocument.Statement[0].Action).toStrictEqual(expectedActionsForRole);
+  });
+
+  it("adds permissions to the role if RoleArn is defined using Fn::GetAtt", () => {
+    stateMachine.properties.RoleArn = { "Fn::GetAtt": ["MyStateMachineRole", "Arn"] };
+    resources["MyStateMachineRole"] = getEmptyStateMachineRole();
+
+    setUpLogging(resources, stateMachine);
+
+    expect(resources["MyStateMachineRole"]).toBeDefined();
+    const role = resources["MyStateMachineRole"];
+    expect(role.Type).toBe("AWS::IAM::Role");
+    expect(role.Properties.Policies).toBeDefined();
+    expect(role.Properties.Policies[0].PolicyDocument.Statement[0].Action).toStrictEqual(expectedActionsForRole);
+  });
+
+  it("adds permissions to the role if RoleArn is defined using Fn::Sub", () => {
+    stateMachine.properties.RoleArn = { "Fn::Sub": "${MyStateMachineRole.Arn}" };
+    resources["MyStateMachineRole"] = getEmptyStateMachineRole();
+
+    setUpLogging(resources, stateMachine);
+
+    expect(resources["MyStateMachineRole"]).toBeDefined();
+    const role = resources["MyStateMachineRole"];
+    expect(role.Type).toBe("AWS::IAM::Role");
+    expect(role.Properties.Policies).toBeDefined();
+    expect(role.Properties.Policies[0].PolicyDocument.Statement[0].Action).toStrictEqual(expectedActionsForRole);
+  });
+
+  it("throws an error for unsupported RoleArn format", () => {
+    stateMachine.properties.RoleArn = { "Fn::Unsupported": "value" };
+
+    expect(() => setUpLogging(resources, stateMachine)).toThrow(
+      "Unsupported RoleArn format: [object Object]. Step Function Instrumentation is not supported. Please open a feature request in https://github.com/DataDog/datadog-cdk-constructs.",
+    );
+  });
+});
+
+describe("buildLogGroupName", () => {
+  it("builds log group name without env", () => {
+    const stateMachine = { resourceKey: "MyStateMachine" } as StateMachine;
+    const logGroupName = buildLogGroupName(stateMachine, undefined);
+    expect(logGroupName).toBe("/aws/vendedlogs/states/MyStateMachine-Logs");
+  });
+
+  it("builds log group name with env", () => {
+    const stateMachine = { resourceKey: "MyStateMachine" } as StateMachine;
+    const logGroupName = buildLogGroupName(stateMachine, "dev");
+    expect(logGroupName).toBe("/aws/vendedlogs/states/MyStateMachine-Logs-dev");
+  });
+});

--- a/serverless/test/step_function/step_function.spec.ts
+++ b/serverless/test/step_function/step_function.spec.ts
@@ -1,0 +1,41 @@
+import { findStateMachines } from "../../src/step_function/step_function";
+
+describe("findStateMachines", () => {
+  it("returns an empty array when no state machines are present", () => {
+    const resources = {
+      SomeOtherResource: {
+        Type: "AWS::Lambda::Function",
+        Properties: {},
+      },
+    };
+
+    const result = findStateMachines(resources);
+    expect(result).toEqual([]);
+  });
+
+  it("returns an array with state machines when they are present", () => {
+    const resources = {
+      FirstStateMachine: {
+        Type: "AWS::StepFunctions::StateMachine",
+        Properties: {
+          DefinitionUri: "state_machine/first.asl.json",
+        },
+      },
+      SecondStateMachine: {
+        Type: "AWS::StepFunctions::StateMachine",
+        Properties: {
+          DefinitionUri: "state_machine/second.asl.json",
+        },
+      },
+      SomeOtherResource: {
+        Type: "AWS::Lambda::Function",
+        Properties: {},
+      },
+    };
+
+    const result = findStateMachines(resources);
+    expect(result).toHaveLength(2);
+    expect(result[0].resourceKey).toBe("FirstStateMachine");
+    expect(result[1].resourceKey).toBe("SecondStateMachine");
+  });
+});


### PR DESCRIPTION
### What does this PR do?
Enables setting up logging for a given state machine:
1. Set log level to ALL
2. Set includeExecutionData to true
3. Set destination log group (if not set already)
4. Add permissions to the state machine role to log to CloudWatch Logs
<!--- A brief description of the change being made with this pull request. --->

### Motivation

This is the first step of instrumenting a step function.

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

#### Automated Testing

Passed the added tests.

#### Manual Testing
##### Steps
1. Run `aws-vault exec sso-serverless-sandbox-account-admin -- tools/create_test_stack.sh` to deploy the macro to sandbox
2. Deploy my SAM app, which includes a State Machine and uses `DatadogServerless` transform

##### Result
1. Both deployments are successful
2. The state machine has:
    1. log level: ALL
    2. include execution data: true
    3. log group set up
<img width="643" alt="image" src="https://github.com/user-attachments/assets/60954601-5ee0-455c-8d79-2a9eb717ec2b" />

3. The state machine can execute successfully


### Additional Notes

Sorry for making this PR so large, but partially set up logging can cause deployment failures in manual test. For example, if log level is ALL and log group is not set, then deployment will fail. Please let me know if any code is not clear to you.

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
