### PR TITLE
[Step Function] 1. Set up skeleton code

### DIFF
--- a/serverless/src/index.ts
+++ b/serverless/src/index.ts
@@ -39,15 +39,7 @@ export const handler = async (event: InputEvent, _: any): Promise<OutputEvent> =
     }
 
     const stepFunctionOutput = await instrumentStateMachines(event);
-    if (stepFunctionOutput.status === FAILURE) {
-      return stepFunctionOutput;
-    }
-
-    return {
-      requestId: event.requestId,
-      status: SUCCESS,
-      fragment,
-    };
+    return stepFunctionOutput;
   } catch (error: any) {
     return {
       requestId: event.requestId,

--- a/serverless/src/index.ts
+++ b/serverless/src/index.ts
@@ -1,6 +1,7 @@
 import { getConfigFromCfnMappings, getConfigFromCfnParams, validateParameters, Configuration } from "./lambda/env";
 import { instrumentLambdas } from "./lambda/lambda";
 import { InputEvent, OutputEvent, SUCCESS, FAILURE } from "./types";
+import { instrumentStateMachines } from "./step_function/step_function";
 import log from "loglevel";
 
 export const handler = async (event: InputEvent, _: any): Promise<OutputEvent> => {
@@ -35,6 +36,11 @@ export const handler = async (event: InputEvent, _: any): Promise<OutputEvent> =
     const lambdaOutput = await instrumentLambdas(event, config);
     if (lambdaOutput.status === FAILURE) {
       return lambdaOutput;
+    }
+
+    const stepFunctionOutput = await instrumentStateMachines(event);
+    if (stepFunctionOutput.status === FAILURE) {
+      return stepFunctionOutput;
     }
 
     return {

--- a/serverless/src/step_function/step_function.ts
+++ b/serverless/src/step_function/step_function.ts
@@ -1,0 +1,43 @@
+import { InputEvent, OutputEvent, SUCCESS, Resources } from "../types";
+import log from "loglevel";
+import { StateMachine, StateMachineProperties } from "step_function/types";
+
+const STATE_MACHINE_RESOURCE_TYPE = "AWS::StepFunctions::StateMachine";
+
+export async function instrumentStateMachines(event: InputEvent): Promise<OutputEvent> {
+  const fragment = event.fragment;
+  const resources = fragment.Resources;
+
+  const stateMachines = findStateMachines(resources);
+  for (const stateMachine of stateMachines) {
+    instrumentStateMachine(resources, stateMachine);
+  }
+
+  return {
+    requestId: event.requestId,
+    status: SUCCESS,
+    fragment,
+  };
+}
+
+function instrumentStateMachine(resources: Resources, stateMachine: StateMachine): void {
+  log.debug(`Instrumenting State Machine ${stateMachine.resourceKey}`);
+}
+
+export function findStateMachines(resources: Resources): StateMachine[] {
+  return Object.entries(resources)
+    .map(([key, resource]) => {
+      if (resource.Type !== STATE_MACHINE_RESOURCE_TYPE) {
+        log.debug(`Resource ${key} is not a State Machine, skipping...`);
+        return;
+      }
+
+      const properties: StateMachineProperties = resource.Properties;
+
+      return {
+        properties: properties,
+        resourceKey: key,
+      } as StateMachine;
+    })
+    .filter((resource) => resource !== undefined) as StateMachine[];
+}

--- a/serverless/src/step_function/types.ts
+++ b/serverless/src/step_function/types.ts
@@ -1,0 +1,33 @@
+// Parsed state machine info from CloudFormation template. For internal use.
+// Not aimed to match any CloudFormation type.
+export interface StateMachine {
+  properties: StateMachineProperties;
+  resourceKey: string;
+}
+
+// Necessary fields from AWS::StepFunctions::StateMachine's Properties field
+export interface StateMachineProperties {
+  LoggingConfiguration?: LoggingConfiguration;
+  RoleArn?: string | { [key: string]: any };
+}
+
+// Matches AWS::StepFunctions::StateMachine LoggingConfiguration
+export interface LoggingConfiguration {
+  Destinations?: LogDestination[];
+  IncludeExecutionData?: boolean;
+  Level?: string;
+}
+
+// Matches AWS::StepFunctions::StateMachine LogDestination
+export interface LogDestination {
+  CloudWatchLogsLogGroup: CloudWatchLogsLogGroup;
+}
+
+// Matches AWS::StepFunctions::StateMachine CloudWatchLogsLogGroup
+export interface CloudWatchLogsLogGroup {
+  LogGroupArn:
+    | string
+    | {
+        "Fn::GetAtt": string[];
+      };
+}

--- a/serverless/test/step_function/step_function.spec.ts
+++ b/serverless/test/step_function/step_function.spec.ts
@@ -1,0 +1,41 @@
+import { findStateMachines } from "../../src/step_function/step_function";
+
+describe("findStateMachines", () => {
+  it("returns an empty array when no state machines are present", () => {
+    const resources = {
+      SomeOtherResource: {
+        Type: "AWS::Lambda::Function",
+        Properties: {},
+      },
+    };
+
+    const result = findStateMachines(resources);
+    expect(result).toEqual([]);
+  });
+
+  it("returns an array with state machines when they are present", () => {
+    const resources = {
+      FirstStateMachine: {
+        Type: "AWS::StepFunctions::StateMachine",
+        Properties: {
+          DefinitionUri: "state_machine/first.asl.json",
+        },
+      },
+      SecondStateMachine: {
+        Type: "AWS::StepFunctions::StateMachine",
+        Properties: {
+          DefinitionUri: "state_machine/second.asl.json",
+        },
+      },
+      SomeOtherResource: {
+        Type: "AWS::Lambda::Function",
+        Properties: {},
+      },
+    };
+
+    const result = findStateMachines(resources);
+    expect(result).toHaveLength(2);
+    expect(result[0].resourceKey).toBe("FirstStateMachine");
+    expect(result[1].resourceKey).toBe("SecondStateMachine");
+  });
+});


### PR DESCRIPTION
### Context of this PR series

Right now the Datadog Serverless CloudFormation Macro only supports instrumenting Lambda functions. This series of PRs makes it also support instrumenting Step Functions.

Instead of merging every PR into main branch, I'm going to merge them into a feature branch `yiming.luo/step-function` to:
1. respect the holiday production freeze
2. avoid releasing partial support for step functions

### What does this PR do?
Sets up skeleton code for supporting step functions:
1. Add some basic step-function specific code in `step_function/step_function.ts`, including `instrumentStateMachines()`
2. Call `instrumentStateMachines()` in the main file `index.ts`
3. Add tests

<!--- A brief description of the change being made with this pull request. --->

### Motivation

To get ready to add step function instrumentation code.

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
1. Pass the added automated tests
2. Manually tested deploying the stacks, with some other changes. See https://github.com/DataDog/datadog-cloudformation-macro/pull/143. I decided to break that PR into smaller ones for easy review, and this PR is the first one.
<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
