### PR TITLE
[Step Function] 3. Create log group

### DIFF
--- a/serverless/src/step_function/log.ts
+++ b/serverless/src/step_function/log.ts
@@ -6,8 +6,9 @@ import { StateMachine } from "./types";
  * Set up logging for the given state machine:
  * 1. Set log level to ALL
  * 2. Set includeExecutionData to true
+ * 3. Create a destination log group (if not set already)
  */
-export function setUpLogging(_resources: Resources, stateMachine: StateMachine): void {
+export function setUpLogging(resources: Resources, stateMachine: StateMachine): void {
   log.debug(`Setting up logging`);
   if (!stateMachine.properties.LoggingConfiguration) {
     stateMachine.properties.LoggingConfiguration = {};
@@ -17,4 +18,42 @@ export function setUpLogging(_resources: Resources, stateMachine: StateMachine):
 
   logConfig.Level = "ALL";
   logConfig.IncludeExecutionData = true;
+
+  if (!logConfig.Destinations) {
+    log.debug(`Log destination not found, creating one`);
+    const logGroupKey = createLogGroup(resources, stateMachine);
+    logConfig.Destinations = [
+      {
+        CloudWatchLogsLogGroup: {
+          LogGroupArn: {
+            "Fn::GetAtt": [logGroupKey, "Arn"],
+          },
+        },
+      },
+    ];
+  } else {
+    log.debug(`Log destination already exists, skipping creating one`);
+  }
 }
+
+function createLogGroup(resources: Resources, stateMachine: StateMachine): string {
+  const logGroupKey = `${stateMachine.resourceKey}LogGroup`;
+  resources[logGroupKey] = {
+    Type: "AWS::Logs::LogGroup",
+    Properties: {
+      LogGroupName: buildLogGroupName(stateMachine, undefined),
+      RetentionInDays: 7,
+    },
+  };
+
+  return logGroupKey;
+}
+
+/**
+ * Builds log group name for a state machine.
+ * @returns log group name like "/aws/vendedlogs/states/MyStateMachine-Logs" (without env)
+ *                           or "/aws/vendedlogs/states/MyStateMachine-Logs-dev" (with env)
+ */
+export const buildLogGroupName = (stateMachine: StateMachine, env: string | undefined): string => {
+  return `/aws/vendedlogs/states/${stateMachine.resourceKey}-Logs${env !== undefined ? "-" + env : ""}`;
+};


### PR DESCRIPTION
### Context of this PR series

Right now the Datadog Serverless CloudFormation Macro only supports instrumenting Lambda functions. This series of PRs makes it also support instrumenting Step Functions.

Instead of merging every PR into main branch, I'm going to merge them into a feature branch `yiming.luo/step-function` to:
1. respect the holiday production freeze
2. avoid releasing partial support for step functions

### What does this PR do?
Create a log group for the state machine if not already created.

<!--- A brief description of the change being made with this pull request. --->

### Motivation

This is one step of instrumenting a state machine.

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
1. Pass the added automated tests
2. Manually tested deploying the stacks, with some other changes. See https://github.com/DataDog/datadog-cloudformation-macro/pull/143. I decided to break that PR into smaller ones for easy review, and this PR is the first one.
<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
