### PR TITLE
[Step Function] 3.2 Load step function config

### DIFF
--- a/serverless/src/index.ts
+++ b/serverless/src/index.ts
@@ -2,6 +2,7 @@ import { validateParameters as validateLambdaParameters, getConfig as getLambdaC
 import { instrumentLambdas } from "./lambda/lambda";
 import { InputEvent, OutputEvent, SUCCESS, FAILURE } from "./types";
 import { instrumentStateMachines } from "./step_function/step_function";
+import { getConfig as getStepFunctionConfig } from "./step_function/env";
 import log from "loglevel";
 
 export const handler = async (event: InputEvent, _: any): Promise<OutputEvent> => {
@@ -27,7 +28,8 @@ export const handler = async (event: InputEvent, _: any): Promise<OutputEvent> =
       return lambdaOutput;
     }
 
-    const stepFunctionOutput = await instrumentStateMachines(event);
+    const stepFunctionConfig = getStepFunctionConfig(event);
+    const stepFunctionOutput = await instrumentStateMachines(event, stepFunctionConfig);
     return stepFunctionOutput;
   } catch (error: any) {
     return {

--- a/serverless/src/step_function/env.ts
+++ b/serverless/src/step_function/env.ts
@@ -1,0 +1,100 @@
+import { InputEvent } from "types";
+import log from "loglevel";
+
+export interface Configuration {
+  // When set, it will be added to the state machine's log group name.
+  env?: string;
+}
+
+const DATADOG = "Datadog";
+const PARAMETERS = "Parameters";
+const envEnvVar = "DD_ENV";
+
+// Same interface as Configuration above, except all parameters are optional, since user does
+// not have to provide the values (in which case we will use the default configuration below).
+interface CfnParams extends Partial<Configuration> {}
+
+export const defaultConfiguration: Configuration = {};
+
+/**
+ * Returns the configuration.
+ * If DatadogServerless transform params are set, then the priority order is:
+ *   1. CloudFormation Macro params
+ *   2. Environment variables
+ *   3. Default configuration
+ * Otherwise, if CloudFormation Mappings for Datadog are set, then the priority order is:
+ *   1. CloudFormation Mappings params
+ *   2. Environment variables
+ *   3. Default configuration
+ * Otherwise, the priority order is:
+ *   1. Environment variables
+ *   2. Default configuration
+ */
+export function getConfig(event: InputEvent): Configuration {
+  let config: Configuration;
+  // Use the parameters given for this specific transform/macro if it exists
+  const transformParams = event.params ?? {};
+  if (Object.keys(transformParams).length > 0) {
+    log.debug("Parsing config from CloudFormation transform/macro parameters");
+    config = getConfigFromCfnParams(transformParams);
+  } else {
+    // If not, check the Mappings section for Datadog config parameters as well
+    log.debug("Parsing config from CloudFormation template mappings");
+    config = getConfigFromCfnMappings(event.fragment.Mappings);
+  }
+  return config;
+}
+
+/**
+ * Returns the default configuration with any values overwritten by environment variables.
+ */
+function getConfigFromEnvVars(): Configuration {
+  const config: Configuration = {
+    ...defaultConfiguration,
+  };
+
+  if (envEnvVar in process.env) {
+    config.env = process.env[envEnvVar];
+  }
+
+  return config;
+}
+
+/**
+ * Parses the Mappings section for Datadog config parameters.
+ * Assumes that the parameters live under the Mappings section in this format:
+ *
+ * Mappings:
+ *  Datadog:
+ *    Parameters:
+ *      addLayers: true
+ *      ...
+ */
+function getConfigFromCfnMappings(mappings: any): Configuration {
+  if (mappings !== undefined && mappings[DATADOG] !== undefined) {
+    return getConfigFromCfnParams(mappings[DATADOG][PARAMETERS]);
+  }
+  log.debug("No Datadog mappings found in the CloudFormation template, using the default config");
+  return getConfigFromEnvVars();
+}
+
+/**
+ * Takes a set of parameters from the CloudFormation template. This could come from either
+ * the Mappings section of the template, or directly from the Parameters under the transform/macro
+ * as the 'params' property under the original InputEvent to the handler in src/index.ts
+ *
+ * Uses these parameters as the Datadog configuration, and for values that are required in the
+ * configuration but not provided in the parameters, uses the default values from
+ * the defaultConfiguration above.
+ */
+function getConfigFromCfnParams(params: CfnParams) {
+  let datadogConfig = params as Partial<Configuration> | undefined;
+  if (datadogConfig === undefined) {
+    log.debug("No Datadog config found, using the default config");
+    datadogConfig = {};
+  }
+  return {
+    ...getConfigFromEnvVars(),
+    ...datadogConfig,
+  };
+}

--- a/serverless/src/step_function/log.ts
+++ b/serverless/src/step_function/log.ts
@@ -6,8 +6,9 @@ import { StateMachine } from "./types";
  * Set up logging for the given state machine:
  * 1. Set log level to ALL
  * 2. Set includeExecutionData to true
+ * 3. Create a destination log group (if not set already)
  */
-export function setUpLogging(_resources: Resources, stateMachine: StateMachine): void {
+export function setUpLogging(resources: Resources, stateMachine: StateMachine): void {
   log.debug(`Setting up logging`);
   if (!stateMachine.properties.LoggingConfiguration) {
     stateMachine.properties.LoggingConfiguration = {};
@@ -17,4 +18,42 @@ export function setUpLogging(_resources: Resources, stateMachine: StateMachine):
 
   logConfig.Level = "ALL";
   logConfig.IncludeExecutionData = true;
+
+  if (!logConfig.Destinations) {
+    log.debug(`Log destination not found, creating one`);
+    const logGroupKey = createLogGroup(resources, stateMachine);
+    logConfig.Destinations = [
+      {
+        CloudWatchLogsLogGroup: {
+          LogGroupArn: {
+            "Fn::GetAtt": [logGroupKey, "Arn"],
+          },
+        },
+      },
+    ];
+  } else {
+    log.debug(`Log destination already exists, skipping creating one`);
+  }
 }
+
+function createLogGroup(resources: Resources, stateMachine: StateMachine): string {
+  const logGroupKey = `${stateMachine.resourceKey}LogGroup`;
+  resources[logGroupKey] = {
+    Type: "AWS::Logs::LogGroup",
+    Properties: {
+      LogGroupName: buildLogGroupName(stateMachine, undefined),
+      RetentionInDays: 7,
+    },
+  };
+
+  return logGroupKey;
+}
+
+/**
+ * Builds log group name for a state machine.
+ * @returns log group name like "/aws/vendedlogs/states/MyStateMachine-Logs" (without env)
+ *                           or "/aws/vendedlogs/states/MyStateMachine-Logs-dev" (with env)
+ */
+export const buildLogGroupName = (stateMachine: StateMachine, env: string | undefined): string => {
+  return `/aws/vendedlogs/states/${stateMachine.resourceKey}-Logs${env !== undefined ? "-" + env : ""}`;
+};

--- a/serverless/src/step_function/step_function.ts
+++ b/serverless/src/step_function/step_function.ts
@@ -2,10 +2,11 @@ import { InputEvent, OutputEvent, SUCCESS, Resources } from "../types";
 import log from "loglevel";
 import { StateMachine, StateMachineProperties } from "./types";
 import { setUpLogging } from "./log";
+import { Configuration } from "./env";
 
 const STATE_MACHINE_RESOURCE_TYPE = "AWS::StepFunctions::StateMachine";
 
-export async function instrumentStateMachines(event: InputEvent): Promise<OutputEvent> {
+export async function instrumentStateMachines(event: InputEvent, config: Configuration): Promise<OutputEvent> {
   const fragment = event.fragment;
   const resources = fragment.Resources;
 

--- a/serverless/test/step_function/env.spec.ts
+++ b/serverless/test/step_function/env.spec.ts
@@ -1,0 +1,85 @@
+import { InputEvent } from "../../src/types";
+import { getConfig } from "../../src/step_function/env";
+
+describe("getConfig", () => {
+  const originalEnv = process.env;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    process.env = originalEnv;
+  });
+
+  // TODO: Change "env" to a field which is in defaultConfig once there is one
+  describe("1. CloudFormation Macro params are set", () => {
+    it("uses CloudFormation Macro params over environment variables and default configuration", () => {
+      const event: InputEvent = {
+        params: {
+          env: "macroEnv",
+        },
+        fragment: {
+          Mappings: {},
+        },
+      } as any;
+
+      process.env.DD_ENV = "envVarEnv";
+
+      const config = getConfig(event);
+      expect(config.env).toBe("macroEnv");
+    });
+  });
+
+  describe("2. CloudFormation Mappings are set", () => {
+    it("uses CloudFormation Mappings params over environment variables and default configuration", () => {
+      const event: InputEvent = {
+        params: {},
+        fragment: {
+          Mappings: {
+            Datadog: {
+              Parameters: {
+                env: "mappingEnv",
+              },
+            },
+          },
+        },
+      } as any;
+
+      process.env.DD_ENV = "envVarEnv";
+
+      const config = getConfig(event);
+      expect(config.env).toBe("mappingEnv");
+    });
+  });
+
+  describe("3. Neither CloudFormation Macro params nor CloudFormation Mappings is set", () => {
+    it("uses environment variables over default configuration", () => {
+      const event: InputEvent = {
+        params: {},
+        fragment: {
+          Mappings: {},
+        },
+      } as any;
+
+      process.env.DD_ENV = "envVarEnv";
+
+      const config = getConfig(event);
+      expect(config.env).toBe("envVarEnv");
+    });
+
+    it("uses default configuration if no other params are set", () => {
+      const event: InputEvent = {
+        params: {},
+        fragment: {
+          Mappings: {},
+        },
+      } as any;
+
+      const config = getConfig(event);
+      expect(config.env).toBe(undefined);
+    });
+  });
+});

--- a/serverless/test/step_function/log.spec.ts
+++ b/serverless/test/step_function/log.spec.ts
@@ -1,6 +1,7 @@
 import { setUpLogging, buildLogGroupName } from "../../src/step_function/log";
 import { Resources } from "types";
 import { StateMachine, LoggingConfiguration, LogDestination } from "../../src/step_function/types";
+import { Configuration } from "../../src/step_function/env";
 
 describe("setUpLogging", () => {
   let resources: Resources;


### PR DESCRIPTION
### Context of this PR series

Right now the Datadog Serverless CloudFormation Macro only supports instrumenting Lambda functions. This series of PRs makes it also support instrumenting Step Functions.

Instead of merging every PR into main branch, I'm going to merge them into a feature branch `yiming.luo/step-function` to avoid releasing partial support for step functions

### What does this PR do?
Supports loading step function config options from:
1. environment variables, e.g. `DD_ENV`
2. "param" section of CloudFormation Macro transform, e.g.
```
Transform:
  - AWS::Serverless-2016-10-31
  - Name: DatadogServerless
    Parameters:
      env: dev
```
3. Mappings section for Datadog, e.g.
```
Mappings:
  Datadog:
    Parameters:
      env: dev
```

<!--- A brief description of the change being made with this pull request. --->

### Motivation

We need to load config params such as env for instrumenting step functions. For example, env will be added as part of log group name.

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
1. Pass the added automated tests
<!--- How did you test this pull request? --->

### Additional Notes
1. Lots of code in `step_function/env.ts` is copied from `lambda/env.ts`. I think it's better to keep Lambda and step function code separate to some extent.
2. In `env.spec.ts`, I can only use the `env` field, which is the only field for now. One problem is that it doesn't have a default value, so I can't test the behavior around default values. I will change to another field once there is one.

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
