### PR TITLE
[Step Function] 3.4 Pass env from config to log group name

### DIFF
--- a/serverless/src/step_function/log.ts
+++ b/serverless/src/step_function/log.ts
@@ -1,6 +1,7 @@
 import { Resources } from "../types";
 import log from "loglevel";
 import { StateMachine } from "./types";
+import { Configuration } from "./env";
 
 /**
  * Set up logging for the given state machine:
@@ -8,7 +9,7 @@ import { StateMachine } from "./types";
  * 2. Set includeExecutionData to true
  * 3. Create a destination log group (if not set already)
  */
-export function setUpLogging(resources: Resources, stateMachine: StateMachine): void {
+export function setUpLogging(resources: Resources, config: Configuration, stateMachine: StateMachine): void {
   log.debug(`Setting up logging`);
   if (!stateMachine.properties.LoggingConfiguration) {
     stateMachine.properties.LoggingConfiguration = {};
@@ -21,7 +22,7 @@ export function setUpLogging(resources: Resources, stateMachine: StateMachine): 
 
   if (!logConfig.Destinations) {
     log.debug(`Log destination not found, creating one`);
-    const logGroupKey = createLogGroup(resources, stateMachine);
+    const logGroupKey = createLogGroup(resources, config, stateMachine);
     logConfig.Destinations = [
       {
         CloudWatchLogsLogGroup: {
@@ -36,12 +37,12 @@ export function setUpLogging(resources: Resources, stateMachine: StateMachine): 
   }
 }
 
-function createLogGroup(resources: Resources, stateMachine: StateMachine): string {
+function createLogGroup(resources: Resources, config: Configuration, stateMachine: StateMachine): string {
   const logGroupKey = `${stateMachine.resourceKey}LogGroup`;
   resources[logGroupKey] = {
     Type: "AWS::Logs::LogGroup",
     Properties: {
-      LogGroupName: buildLogGroupName(stateMachine, undefined),
+      LogGroupName: buildLogGroupName(stateMachine, config.env),
       RetentionInDays: 7,
     },
   };

--- a/serverless/src/step_function/step_function.ts
+++ b/serverless/src/step_function/step_function.ts
@@ -25,7 +25,7 @@ export async function instrumentStateMachines(event: InputEvent, config: Configu
 function instrumentStateMachine(resources: Resources, config: Configuration, stateMachine: StateMachine): void {
   log.debug(`Instrumenting State Machine ${stateMachine.resourceKey}`);
 
-  setUpLogging(resources, stateMachine);
+  setUpLogging(resources, config, stateMachine);
 }
 
 export function findStateMachines(resources: Resources): StateMachine[] {

--- a/serverless/test/step_function/log.spec.ts
+++ b/serverless/test/step_function/log.spec.ts
@@ -4,6 +4,7 @@ import { StateMachine, LoggingConfiguration, LogDestination } from "../../src/st
 
 describe("setUpLogging", () => {
   let resources: Resources;
+  const config = { env: "dev" };
   let stateMachine: StateMachine;
 
   beforeEach(() => {
@@ -15,7 +16,7 @@ describe("setUpLogging", () => {
   });
 
   it("sets up log config if not present", () => {
-    setUpLogging(resources, stateMachine);
+    setUpLogging(resources, config, stateMachine);
 
     expect(stateMachine.properties.LoggingConfiguration).toBeDefined();
     const logConfig = stateMachine.properties.LoggingConfiguration as LoggingConfiguration;
@@ -39,7 +40,7 @@ describe("setUpLogging", () => {
       ],
     };
 
-    setUpLogging(resources, stateMachine);
+    setUpLogging(resources, config, stateMachine);
 
     expect(stateMachine.properties.LoggingConfiguration).toBeDefined();
     const logConfig = stateMachine.properties.LoggingConfiguration as LoggingConfiguration;
@@ -51,12 +52,12 @@ describe("setUpLogging", () => {
   });
 
   it("creates a log group if not present", () => {
-    setUpLogging(resources, stateMachine);
+    setUpLogging(resources, config, stateMachine);
 
     expect(resources["MyStateMachineLogGroup"]).toStrictEqual({
       Type: "AWS::Logs::LogGroup",
       Properties: {
-        LogGroupName: "/aws/vendedlogs/states/MyStateMachine-Logs",
+        LogGroupName: "/aws/vendedlogs/states/MyStateMachine-Logs-dev",
         RetentionInDays: 7,
       },
     });


### PR DESCRIPTION
### Context of this PR series

Right now the Datadog Serverless CloudFormation Macro only supports instrumenting Lambda functions. This series of PRs makes it also support instrumenting Step Functions.

Instead of merging every PR into main branch, I'm going to merge them into a feature branch `yiming.luo/step-function` to avoid releasing partial support for step functions.

### What does this PR do?
Pass the `env` field set in step function config to log group name, so the created log group name can be like `/aws/vendedlogs/states/MyStateMachine-Logs-dev`

<!--- A brief description of the change being made with this pull request. --->

### Motivation

We want env field to be part of log group name.

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
1. Pass the added automated tests in `step_function/log.spec.ts`
<!--- How did you test this pull request? --->

### Additional Notes

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
