### PR TITLE
[Step Function] 4. Add permissions to state machine role

### DIFF
--- a/serverless/src/step_function/log.ts
+++ b/serverless/src/step_function/log.ts
@@ -3,11 +3,32 @@ import log from "loglevel";
 import { StateMachine } from "./types";
 import { Configuration } from "./env";
 
+const unsupportedCaseErrorMessage =
+  "Step Function Instrumentation is not supported. \
+Please open a feature request in https://github.com/DataDog/datadog-cloudformation-macro.";
+
+const FN_SUB = "Fn::Sub";
+export const FN_GET_ATT = "Fn::GetAtt";
+// Permissions required for the state machine role to log to CloudWatch Logs
+export const ROLE_ACTIONS = [
+  "logs:CreateLogDelivery",
+  "logs:CreateLogStream",
+  "logs:GetLogDelivery",
+  "logs:UpdateLogDelivery",
+  "logs:DeleteLogDelivery",
+  "logs:ListLogDeliveries",
+  "logs:PutLogEvents",
+  "logs:PutResourcePolicy",
+  "logs:DescribeResourcePolicies",
+  "logs:DescribeLogGroups",
+];
+
 /**
  * Set up logging for the given state machine:
  * 1. Set log level to ALL
  * 2. Set includeExecutionData to true
  * 3. Create a destination log group (if not set already)
+ * 4. Add permissions to the state machine role to log to CloudWatch Logs
  */
 export function setUpLogging(resources: Resources, config: Configuration, stateMachine: StateMachine): void {
   log.debug(`Setting up logging`);
@@ -46,6 +67,79 @@ function createLogGroup(resources: Resources, config: Configuration, stateMachin
       RetentionInDays: 7,
     },
   };
+
+  let role;
+  if (stateMachine.properties.RoleArn) {
+    log.debug(`A role is already defined. Parsing its resource key from the roleArn.`);
+    const roleArn = stateMachine.properties.RoleArn;
+
+    if (typeof roleArn !== "object") {
+      throw new Error(`RoleArn is not an object. ${unsupportedCaseErrorMessage}`);
+    }
+
+    // There are many ways a user can specify a state machine role in a CloudFormation template. For now
+    // we only support the simple cases. We can support more cases as needed.
+    let roleKey;
+    if (roleArn[FN_GET_ATT]) {
+      // e.g.
+      //   Fn::GetAtt: [MyStateMachineRole, "Arn"]
+      roleKey = roleArn[FN_GET_ATT][0];
+    } else if (roleArn[FN_SUB]) {
+      // e.g.
+      //   Fn::Sub: ${StatesExecutionRole.Arn}
+      const arnMatch = roleArn[FN_SUB].match(/^\${(.*)\.Arn}$/);
+      if (arnMatch) {
+        roleKey = arnMatch[1];
+      } else {
+        throw new Error(`Unsupported Fn::Sub format: ${roleArn[FN_SUB]}. ${unsupportedCaseErrorMessage}`);
+      }
+    } else {
+      throw new Error(`Unsupported RoleArn format: ${roleArn}. ${unsupportedCaseErrorMessage}`);
+    }
+    log.debug(`Found State Machine role Key: ${roleKey}`);
+    role = resources[roleKey];
+  } else {
+    log.debug(`No role is defined. Creating one.`);
+    const roleKey = `${stateMachine.resourceKey}Role`;
+    role = {
+      Type: "AWS::IAM::Role",
+      Properties: {
+        AssumeRolePolicyDocument: {
+          Version: "2012-10-17",
+          Statement: [
+            {
+              Effect: "Allow",
+              Principal: {
+                Service: "states.amazonaws.com",
+              },
+              Action: "sts:AssumeRole",
+            },
+          ],
+        },
+        Policies: [],
+      },
+    };
+    resources[roleKey] = role;
+    stateMachine.properties.RoleArn = { FN_GET_ATT: [roleKey, "Arn"] };
+  }
+
+  log.debug(`Adding a policy to the role to grant permissions to the log group`);
+  if (!role.Properties.Policies) {
+    role.Properties.Policies = [];
+  }
+  role.Properties.Policies.push({
+    PolicyName: `${stateMachine.resourceKey}LogPolicy`,
+    PolicyDocument: {
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Action: ROLE_ACTIONS,
+          Resource: "*",
+        },
+      ],
+    },
+  });
 
   return logGroupKey;
 }


### PR DESCRIPTION
### Context of this PR series

Right now the Datadog Serverless CloudFormation Macro only supports instrumenting Lambda functions. This series of PRs makes it also support instrumenting Step Functions.

Instead of merging every PR into main branch, I'm going to merge them into a feature branch `yiming.luo/step-function` to avoid releasing partial support for step functions

### What does this PR do?
Add permissions to the state machine role to allow it to log to CloudWatch Logs.

<!--- A brief description of the change being made with this pull request. --->

### Motivation

This is one step of instrumenting a state machine.

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
1. Pass the added automated tests
2. Manually tested deploying the stacks, with some other changes. See https://github.com/DataDog/datadog-cloudformation-macro/pull/143. I decided to break that PR into smaller ones for easy review, and this PR is the first one.
<!--- How did you test this pull request? --->

### Additional Notes

There are multiple ways for a user to specify a state machine role in a CloudFormation template. For example, here's what I found by checking a few samples from public code on GitHub by searching for [Type: AWS::StepFunctions::StateMachine](https://github.com/search?q=%22Type%3A+AWS%3A%3AStepFunctions%3A%3AStateMachine%22+language%3AYAML&type=code&l=YAML)

```
RoleArn:
  Fn::Sub: ${StatesExecutionRole.Arn}
```
```
RoleArn: !Ref StepFunctionExecutionRoleArn
```
```
RoleArn: !GetAtt StepFunctionsSampleRole.Arn # 5 samples
```
```
RoleArn: !ImportValue cfn-utilities:MasterRoleArn
```

This PR supports the `Fn::Sub` and `Fn::GetAtt` cases, which are easy to support. We won't support more complicated cases for now until a user asks us to do so.

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
