### PR TITLE
[Step Function] 5. Add forwarder

### DIFF
--- a/serverless/src/lambda/forwarder.ts
+++ b/serverless/src/lambda/forwarder.ts
@@ -1,6 +1,6 @@
 import { CloudWatchLogs } from "aws-sdk";
 import { LambdaFunction } from "./layer";
-import { Resources } from "../types";
+import { Resources, LogGroup } from "../types";
 import log from "loglevel";
 
 const LOG_GROUP_TYPE = "AWS::Logs::LogGroup";
@@ -14,12 +14,7 @@ export const SUBSCRIPTION_FILTER_NAME = "datadog-serverless-macro-filter";
 
 export interface LogGroupDefinition {
   key: string;
-  logGroupResource: {
-    Type: string;
-    Properties: {
-      LogGroupName: string | { [fn: string]: any };
-    };
-  };
+  logGroupResource: LogGroup;
 }
 
 interface SubscriptionResource {

--- a/serverless/src/step_function/env.ts
+++ b/serverless/src/step_function/env.ts
@@ -3,6 +3,8 @@ import { ConfigLoader } from "../env";
 export interface Configuration {
   // When set, it will be added to the state machine's log group name.
   env?: string;
+  // When set, the forwarder will subscribe to the state machine's log group.
+  stepFunctionForwarderArn?: string;
 }
 
 const envEnvVar = "DD_ENV";

--- a/serverless/src/step_function/forwarder.ts
+++ b/serverless/src/step_function/forwarder.ts
@@ -4,7 +4,7 @@ import { StateMachine } from "./types";
 import { findLogGroup } from "./log";
 import log from "loglevel";
 
-export const SUBSCRIPTION_FILTER_PREFIX = "DatadogSubscriptionFilter";
+export const SUBSCRIPTION_FILTER_PREFIX = "LogGroupDatadogSubscriptionFilter";
 
 /**
  * Subscribe the forwarder to the state machine's log group.
@@ -20,6 +20,6 @@ export function addForwarder(resources: Resources, config: Configuration, stateM
       FilterPattern: "",
     },
   };
-  const subscriptionFilterKey = `${stateMachine.resourceKey}LogGroupDatadogSubscriptionFilter`;
+  const subscriptionFilterKey = stateMachine.resourceKey + "LogGroupDatadogSubscriptionFilter";
   resources[subscriptionFilterKey] = subscriptionFilter;
 }

--- a/serverless/src/step_function/forwarder.ts
+++ b/serverless/src/step_function/forwarder.ts
@@ -1,0 +1,25 @@
+import { Resources } from "../types";
+import { Configuration } from "./env";
+import { StateMachine } from "./types";
+import { findLogGroup } from "./log";
+import log from "loglevel";
+
+export const SUBSCRIPTION_FILTER_PREFIX = "DatadogSubscriptionFilter";
+
+/**
+ * Subscribe the forwarder to the state machine's log group.
+ */
+export function addForwarder(resources: Resources, config: Configuration, stateMachine: StateMachine): void {
+  log.debug(`Subscribing the forwarder to the log group...`);
+  const logGroup = findLogGroup(resources, stateMachine);
+  const subscriptionFilter = {
+    Type: "AWS::Logs::SubscriptionFilter",
+    Properties: {
+      LogGroupName: logGroup.Properties.LogGroupName,
+      DestinationArn: config.stepFunctionForwarderArn,
+      FilterPattern: "",
+    },
+  };
+  const subscriptionFilterKey = `${stateMachine.resourceKey}LogGroupDatadogSubscriptionFilter`;
+  resources[subscriptionFilterKey] = subscriptionFilter;
+}

--- a/serverless/src/step_function/step_function.ts
+++ b/serverless/src/step_function/step_function.ts
@@ -3,6 +3,7 @@ import log from "loglevel";
 import { StateMachine, StateMachineProperties } from "./types";
 import { Configuration } from "./env";
 import { setUpLogging } from "./log";
+import { addForwarder } from "./forwarder";
 
 const STATE_MACHINE_RESOURCE_TYPE = "AWS::StepFunctions::StateMachine";
 
@@ -26,6 +27,12 @@ function instrumentStateMachine(resources: Resources, config: Configuration, sta
   log.debug(`Instrumenting State Machine ${stateMachine.resourceKey}`);
 
   setUpLogging(resources, config, stateMachine);
+
+  if (config.stepFunctionForwarderArn !== undefined) {
+    addForwarder(resources, config, stateMachine);
+  } else {
+    log.debug("Forwarder ARN not provided, no log group subscriptions will be added");
+  }
 }
 
 export function findStateMachines(resources: Resources): StateMachine[] {

--- a/serverless/src/types.ts
+++ b/serverless/src/types.ts
@@ -33,3 +33,10 @@ export interface OutputEvent {
   fragment: CfnTemplate;
   errorMessage?: string;
 }
+
+export interface LogGroup {
+  Type: string;
+  Properties: {
+    LogGroupName: string | { [fn: string]: any };
+  };
+}

--- a/serverless/test/step_function/forwarder.spec.ts
+++ b/serverless/test/step_function/forwarder.spec.ts
@@ -21,7 +21,7 @@ describe("addForwarder", () => {
 
     addForwarder(resources, config, stateMachine);
 
-    const subscriptionFilterKey = `${stateMachine.resourceKey}LogGroup${SUBSCRIPTION_FILTER_PREFIX}`;
+    const subscriptionFilterKey = stateMachine.resourceKey + SUBSCRIPTION_FILTER_PREFIX;
     expect(resources[subscriptionFilterKey]).toEqual({
       Type: "AWS::Logs::SubscriptionFilter",
       Properties: {

--- a/serverless/test/step_function/forwarder.spec.ts
+++ b/serverless/test/step_function/forwarder.spec.ts
@@ -1,0 +1,34 @@
+import { addForwarder, SUBSCRIPTION_FILTER_PREFIX } from "../../src/step_function/forwarder";
+import { findLogGroup } from "../../src/step_function/log";
+import { Resources } from "../../src/types";
+
+jest.mock("../../src/step_function/log");
+
+describe("addForwarder", () => {
+  it("adds a subscription filter to the log group", () => {
+    const resources: Resources = {};
+    const config = {
+      stepFunctionForwarderArn: "arn:aws:lambda:us-east-1:123456789012:function:my-function",
+    };
+    const stateMachine = {
+      resourceKey: "MyStateMachine",
+    } as any;
+    (findLogGroup as jest.Mock).mockReturnValue({
+      Properties: {
+        LogGroupName: "/aws/lambda/my-function",
+      },
+    });
+
+    addForwarder(resources, config, stateMachine);
+
+    const subscriptionFilterKey = `${stateMachine.resourceKey}LogGroup${SUBSCRIPTION_FILTER_PREFIX}`;
+    expect(resources[subscriptionFilterKey]).toEqual({
+      Type: "AWS::Logs::SubscriptionFilter",
+      Properties: {
+        LogGroupName: "/aws/lambda/my-function",
+        DestinationArn: config.stepFunctionForwarderArn,
+        FilterPattern: "",
+      },
+    });
+  });
+});


### PR DESCRIPTION
### Context of this PR series

Right now the Datadog Serverless CloudFormation Macro only supports instrumenting Lambda functions. This series of PRs makes it also support instrumenting Step Functions.

Instead of merging every PR into main branch, I'm going to merge them into a feature branch `yiming.luo/step-function` to avoid releasing partial support for step functions

### What does this PR do?
Subscribe the forwarder Lambda function to the state machine's log group, by creating a subscription filter.

<!--- A brief description of the change being made with this pull request. --->

### Motivation

This is one step of instrumenting a state machine.

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
1. Pass the added automated tests
2. Manually tested deploying the CloudFormation Macro stack then the app stack. A subscription filter is created:
<img width="988" alt="image" src="https://github.com/user-attachments/assets/61ae3132-5281-4f27-8873-75aaee3c5fcb" />

<!--- How did you test this pull request? --->

### Additional Notes

The forwarder Lambda should be already created. We ask the user to specify it using the new `stepFunctionForwarderArn` field. I decided not to use the existing field `forwarderArn`, which is being used for Lambda, because it has some trivial interaction with other fields. For example:
> "setting `forwarderArn` with `addExtension` and/or `extensionLayerVersion` as these parameters cannot be set at the same time.",

https://github.com/DataDog/datadog-cloudformation-macro/blob/yiming.luo/step-function/serverless/src/lambda/env.ts#L225

If a user uses `forwarderArn` to set forwarder ARN for step functions, they will also have to use forwarder for Lambda (which is not recommended) and won't be able to use extension for Lambda.

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
