### PR TITLE
[Step Function] 6.2 Refactor Lambda tag code

### DIFF
--- a/serverless/src/common/tags.ts
+++ b/serverless/src/common/tags.ts
@@ -1,0 +1,56 @@
+const SERVICE = "service";
+const ENV = "env";
+const VERSION = "version";
+const MACRO_VERSION = "dd_sls_macro";
+
+export interface TaggableResource {
+  properties: {
+    Tags?: { Key: string; Value: string }[];
+  };
+}
+
+export interface ConfigurationWithTags {
+  env?: string;
+  service?: string;
+  version?: string;
+  tags?: string;
+}
+
+export function addDDTags(resource: TaggableResource, config: ConfigurationWithTags): void {
+  const tags = resource.properties.Tags ?? [];
+
+  const service = tags.find((tag) => tag.Key === SERVICE);
+  const env = tags.find((tag) => tag.Key === ENV);
+  const version = tags.find((tag) => tag.Key === VERSION);
+
+  if (config.service && !service) {
+    tags.push({ Key: SERVICE, Value: config.service });
+  }
+  if (config.env && !env) {
+    tags.push({ Key: ENV, Value: config.env });
+  }
+  if (config.version && !version) {
+    tags.push({ Key: VERSION, Value: config.version });
+  }
+  if (config.tags) {
+    const tagsArray = config.tags.split(",");
+    tagsArray.forEach((tag: string) => {
+      const [key, value] = tag.split(":");
+      const keyDoesntExsist = !tags.find((tag) => tag.Key === key);
+      if (key && value && keyDoesntExsist) {
+        tags.push({ Key: key, Value: value });
+      }
+    });
+  }
+
+  resource.properties.Tags = tags;
+}
+
+export function addMacroTag(resource: TaggableResource, version: string | undefined): void {
+  if (!version) return;
+
+  const tags = resource.properties.Tags ?? [];
+  tags.push({ Value: `v${version}`, Key: MACRO_VERSION });
+
+  resource.properties.Tags = tags;
+}

--- a/serverless/src/lambda/env.ts
+++ b/serverless/src/lambda/env.ts
@@ -1,9 +1,10 @@
 import { getGitTagsFromParam } from "./git";
 import { LambdaFunction, runtimeLookup, RuntimeType } from "./layer";
 import { ConfigLoader } from "../common/env";
+import { ConfigurationWithTags } from "../common/tags";
 import log from "loglevel";
 
-export interface Configuration {
+export interface Configuration extends ConfigurationWithTags {
   // Whether to add the Datadog Lambda Library layers, or expect the users to bring their own
   addLayers: boolean;
   // Whether to add the Datadog Extension Library layer

--- a/serverless/src/lambda/lambda.ts
+++ b/serverless/src/lambda/lambda.ts
@@ -1,7 +1,8 @@
 import { Configuration, setEnvConfiguration } from "./env";
 import { findLambdas, applyLayers, applyExtensionLayer, LambdaFunction } from "./layer";
 import { getTracingMode, enableTracing, MissingIamRoleError, TracingMode } from "./tracing";
-import { addDDTags, addMacroTag, addCDKTag, addSAMTag } from "./tags";
+import { addCDKTag, addSAMTag } from "./tags";
+import { addDDTags, addMacroTag } from "../common/tags";
 import { redirectHandlers } from "./redirect";
 import { addCloudWatchForwarderSubscriptions } from "./forwarder";
 import { CloudWatchLogs } from "aws-sdk";
@@ -101,11 +102,15 @@ export async function instrumentLambdas(event: InputEvent, config: Configuration
   // Add the optional datadog tags if forwarder is being used
   if (config.forwarderArn) {
     log.debug("Adding optional tags...");
-    addDDTags(lambdas, config);
+    for (const lam of lambdas) {
+      addDDTags(lam, config);
+    }
   }
 
   log.debug("Adding macro version tag...");
-  addMacroTag(lambdas, version);
+  for (const lam of lambdas) {
+    addMacroTag(lam, version);
+  }
 
   log.debug("Adding dd_sls_macro_by tag...");
   if (resources.CDKMetadata) {

--- a/serverless/src/lambda/layer.ts
+++ b/serverless/src/lambda/layer.ts
@@ -1,6 +1,7 @@
 import { Resources, Parameters, CFN_IF_FUNCTION_STRING } from "../common/types";
 import { FunctionProperties } from "./types";
 import { LambdaLayersProperty } from "./types";
+import { TaggableResource } from "../common/tags";
 import log from "loglevel";
 
 const LAMBDA_FUNCTION_RESOURCE_TYPE = "AWS::Lambda::Function";
@@ -22,7 +23,7 @@ export enum ArchitectureType {
 
 // Self defined interface that only applies to the macro - the FunctionProperties interface
 // defined in index.ts matches the CloudFormation AWS::Lambda::Function Properties interface.
-export interface LambdaFunction {
+export interface LambdaFunction extends TaggableResource {
   properties: FunctionProperties;
   key: string;
   runtimeType: RuntimeType;

--- a/serverless/src/lambda/tags.ts
+++ b/serverless/src/lambda/tags.ts
@@ -1,56 +1,7 @@
-import { Configuration } from "./env";
 import { LambdaFunction } from "./layer";
 
-const SERVICE = "service";
-const ENV = "env";
-const VERSION = "version";
-const MACRO_VERSION = "dd_sls_macro";
 // Following the same pattern from SAM
 const MACRO_BY = "dd_sls_macro_by";
-
-export function addDDTags(lambdas: LambdaFunction[], config: Configuration): void {
-  // Add the tags for each function, unless a tag already exists.
-  lambdas.forEach((lambda) => {
-    const tags = lambda.properties.Tags ?? [];
-
-    const service = tags.find((tag) => tag.Key === SERVICE);
-    const env = tags.find((tag) => tag.Key === ENV);
-    const version = tags.find((tag) => tag.Key === VERSION);
-
-    if (config.service && !service) {
-      tags.push({ Key: SERVICE, Value: config.service });
-    }
-    if (config.env && !env) {
-      tags.push({ Key: ENV, Value: config.env });
-    }
-    if (config.version && !version) {
-      tags.push({ Key: VERSION, Value: config.version });
-    }
-    if (config.tags) {
-      const tagsArray = config.tags.split(",");
-      tagsArray.forEach((tag: string) => {
-        const [key, value] = tag.split(":");
-        const keyDoesntExsist = !tags.find((tag) => tag.Key === key);
-        if (key && value && keyDoesntExsist) {
-          tags.push({ Key: key, Value: value });
-        }
-      });
-    }
-
-    lambda.properties.Tags = tags;
-  });
-}
-
-export function addMacroTag(lambdas: LambdaFunction[], version: string | undefined): void {
-  if (!version) return;
-
-  lambdas.forEach((lambda) => {
-    const tags = lambda.properties.Tags ?? [];
-    tags.push({ Value: `v${version}`, Key: MACRO_VERSION });
-
-    lambda.properties.Tags = tags;
-  });
-}
 
 export function addCDKTag(lambdas: LambdaFunction[]): void {
   lambdas.forEach((lambda) => {

--- a/serverless/test/lambda/tags.spec.ts
+++ b/serverless/test/lambda/tags.spec.ts
@@ -1,6 +1,7 @@
 import { LambdaConfigLoader } from "../../src/lambda/env";
 import { RuntimeType, LambdaFunction } from "../../src/lambda/layer";
-import { addDDTags, addMacroTag, addCDKTag, addSAMTag } from "../../src/lambda/tags";
+import { addCDKTag, addSAMTag } from "../../src/lambda/tags";
+import { addDDTags, addMacroTag } from "../../src/common/tags";
 
 function mockLambdaFunction(tags: { Key: string; Value: string }[]) {
   return {
@@ -33,14 +34,14 @@ describe("addDDTags", () => {
       { Key: "team", Value: "serverless" },
     ];
     const lambda = mockLambdaFunction(existingTags);
-    addDDTags([lambda], config);
+    addDDTags(lambda, config);
 
     expect(lambda.properties.Tags).toEqual([...existingTags, { Key: "project", Value: "marvel" }]);
   });
 
   it("does not add tags if provided config doesn't have tags", () => {
     const lambda = mockLambdaFunction([]);
-    addDDTags([lambda], configLoader.defaultConfiguration);
+    addDDTags(lambda, configLoader.defaultConfiguration);
 
     expect(lambda.properties.Tags).toEqual([]);
   });
@@ -64,7 +65,7 @@ describe("addDDTags", () => {
         service: "my-service",
       };
       const lambda = mockLambdaFunction([]);
-      addDDTags([lambda], config);
+      addDDTags(lambda, config);
 
       expect(lambda.properties.Tags).toEqual([
         { Key: "service", Value: "my-service" },
@@ -82,7 +83,7 @@ describe("addDDTags", () => {
       tags: "team:avengers,project:marvel",
     };
     const lambda = mockLambdaFunction([]);
-    addDDTags([lambda], config);
+    addDDTags(lambda, config);
 
     expect(lambda.properties.Tags).toEqual([
       { Key: "service", Value: "my-service" },
@@ -105,7 +106,7 @@ describe("addDDTags", () => {
       { Key: "project", Value: "lambda" },
     ];
     const lambda = mockLambdaFunction(existingTags);
-    addDDTags([lambda], config);
+    addDDTags(lambda, config);
 
     expect(lambda.properties.Tags).toEqual([
       { Key: "env", Value: "dev" },
@@ -121,14 +122,14 @@ describe("addMacroTag", () => {
   it("does not update tags if no version is passed in", () => {
     const existingTags = [{ Key: "band", Value: "ironmaiden" }];
     const lambda = mockLambdaFunction(existingTags);
-    addMacroTag([lambda], undefined);
+    addMacroTag(lambda, undefined);
 
     expect(lambda.properties.Tags).toEqual(existingTags);
   });
 
   it("creates tags property if needed", () => {
     const lambda = mockLambdaFunction([]);
-    addMacroTag([lambda], "6.6.6");
+    addMacroTag(lambda, "6.6.6");
 
     expect(lambda.properties.Tags).toEqual([{ Key: "dd_sls_macro", Value: "v6.6.6" }]);
   });
@@ -136,7 +137,7 @@ describe("addMacroTag", () => {
   it("appends version tag if needed", () => {
     const existingTags = [{ Key: "env", Value: "dev" }];
     const lambda = mockLambdaFunction(existingTags);
-    addMacroTag([lambda], "6.6.6");
+    addMacroTag(lambda, "6.6.6");
 
     expect(lambda.properties.Tags).toEqual([
       { Key: "env", Value: "dev" },


### PR DESCRIPTION
### What does this PR do?
#### High level
Most of the code for adding tags to a Lambda function can be reused for tagging a state machine. This PR refactors Lambda tagging code, so it's easier to reuse it for step functions.

#### Details
Right now there are 4 functions for tagging a Lambda function:
```
function addDDTags(lambdas: LambdaFunction[], config: Configuration): void;
function addMacroTag(lambdas: LambdaFunction[], version: string | undefined): void;
function addCDKTag(lambdas: LambdaFunction[]): void;
function addSAMTag(lambdas: LambdaFunction[]): void;
```

`addDDTags()`, for example, takes `LambdaFunction` and Lambda's `LambdaFunction`, which not easily extensible to state machines.

This PR:
1. creates an interface `TaggableResource`, which is extended by `LambdaFunction` and will be extended by `StateMachine` in the next PR https://github.com/DataDog/datadog-cloudformation-macro/pull/157
2. creates an interface `ConfigurationWithTags`, which is extended by Lambda's `Configuration` interface. It will be also extended by state machine's `Configuration` in the next PR https://github.com/DataDog/datadog-cloudformation-macro/pull/157
3. moves `addDDTags()` and `addMacroTag()` from `lambda/tags.ts` to `common/tags.ts`
4. makes `addDDTags()` and `addMacroTag()` take a single `TaggableResource` instead of a list of `LambdaFunction`, and take `ConfigurationWithTags` instead of Lambda's `Configuration`

<!--- A brief description of the change being made with this pull request. --->

### Motivation

To prepare for adding tags to state machines.

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

Pass the existing automated tests.

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
