### PR TITLE
[Step Function] 6.3 Set tags

### DIFF
--- a/serverless/src/step_function/env.ts
+++ b/serverless/src/step_function/env.ts
@@ -1,8 +1,15 @@
 import { ConfigLoader } from "../common/env";
+import { ConfigurationWithTags } from "common/tags";
 
-export interface Configuration {
-  // When set, it will be added to the state machine's log group name.
+export interface Configuration extends ConfigurationWithTags {
+  // When set, it will be added to the state machine's log group name and added as a tag.
   env?: string;
+  // When set, it will be added as a tag of the state machine.
+  service?: string;
+  // When set, it will be added as a tag of the state machine.
+  version?: string;
+  // Custom tags to be added to the state machine, in the format "key1:value1,key2:value2".
+  tags?: string;
   // When set, the forwarder will subscribe to the state machine's log group.
   stepFunctionForwarderArn?: string;
 }

--- a/serverless/src/step_function/step_function.ts
+++ b/serverless/src/step_function/step_function.ts
@@ -4,6 +4,7 @@ import { StateMachine, StateMachineProperties } from "./types";
 import { Configuration } from "./env";
 import { setUpLogging } from "./log";
 import { addForwarder } from "./forwarder";
+import { addTags } from "./tags";
 
 const STATE_MACHINE_RESOURCE_TYPE = "AWS::StepFunctions::StateMachine";
 
@@ -33,6 +34,8 @@ function instrumentStateMachine(resources: Resources, config: Configuration, sta
   } else {
     log.debug("Forwarder ARN not provided, no log group subscriptions will be added");
   }
+
+  addTags(config, stateMachine);
 }
 
 export function findStateMachines(resources: Resources): StateMachine[] {

--- a/serverless/src/step_function/tags.ts
+++ b/serverless/src/step_function/tags.ts
@@ -1,0 +1,18 @@
+import { StateMachine } from "./types";
+import { Configuration } from "./env";
+import { version } from "../../package.json";
+import { addDDTags, addMacroTag } from "../common/tags";
+
+const DD_TRACE_ENABLED = "DD_TRACE_ENABLED";
+
+export function addTags(config: Configuration, stateMachine: StateMachine): void {
+  addDDTags(stateMachine, config);
+  addMacroTag(stateMachine, version);
+  addDDTraceEnabledTag(stateMachine);
+}
+
+function addDDTraceEnabledTag(stateMachine: StateMachine): void {
+  const tags = stateMachine.properties.Tags ?? [];
+  tags.push({ Key: DD_TRACE_ENABLED, Value: "true" });
+  stateMachine.properties.Tags = tags;
+}

--- a/serverless/src/step_function/types.ts
+++ b/serverless/src/step_function/types.ts
@@ -1,6 +1,8 @@
+import { TaggableResource } from "common/tags";
+
 // Parsed state machine info from CloudFormation template. For internal use.
 // Not aimed to match any CloudFormation type.
-export interface StateMachine {
+export interface StateMachine extends TaggableResource {
   properties: StateMachineProperties;
   resourceKey: string;
 }
@@ -9,6 +11,7 @@ export interface StateMachine {
 export interface StateMachineProperties {
   LoggingConfiguration?: LoggingConfiguration;
   RoleArn?: string | { [key: string]: any };
+  Tags?: { Key: string; Value: string }[];
 }
 
 // Matches AWS::StepFunctions::StateMachine LoggingConfiguration

--- a/serverless/test/step_function/tags.spec.ts
+++ b/serverless/test/step_function/tags.spec.ts
@@ -1,0 +1,30 @@
+import { addTags } from "../../src/step_function/tags";
+import { StateMachine } from "../../src/step_function/types";
+import { Configuration } from "../../src/step_function/env";
+
+describe("addTags", () => {
+  it("adds necessary tags", () => {
+    const stateMachine: StateMachine = {
+      properties: {},
+    } as any;
+
+    const config: Configuration = {
+      env: "dev",
+      service: "my-service",
+      version: "1.0.0",
+      tags: "tag1:value1,tag2:value2",
+    };
+
+    addTags(config, stateMachine);
+    const tags = stateMachine.properties.Tags;
+    expect(tags).toStrictEqual([
+      { Key: "service", Value: "my-service" },
+      { Key: "env", Value: "dev" },
+      { Key: "version", Value: "1.0.0" },
+      { Key: "tag1", Value: "value1" },
+      { Key: "tag2", Value: "value2" },
+      { Key: "dd_sls_macro", Value: expect.any(String) },
+      { Key: "DD_TRACE_ENABLED", Value: "true" },
+    ]);
+  });
+});


### PR DESCRIPTION
### Context of this PR series

Right now the Datadog Serverless CloudFormation Macro only supports instrumenting Lambda functions. This series of PRs makes it also support instrumenting Step Functions.

Instead of merging every PR into main branch, I'm going to merge them into a feature branch `yiming.luo/step-function` to avoid releasing partial support for step functions

### What does this PR do?
Set tags on the state machine. For example, if the user specifies this configuration in the CloudFormation template:
```
Transform:
  - Name: DatadogServerless
    Parameters:
      service: "my-service"
      env: "dev"
      version: "1.0.0"
      tags: "tag-key1:tag-value1,tag-key2:tag-value2"
      ...
```

Then we will set these tags on the state machine:
```
service: "my-service"
env: "dev"
version: "1.0.0"
tag-key1: "tag-value1"
tag-key2: "tag-value2"
DD_TRACE_ENABLED: "true"
dd_sls_macro: "0.15.0" # current version of datadog-cloudformation-macro
```

<!--- A brief description of the change being made with this pull request. --->

### Motivation

This is one step of instrumenting a state machine.

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
#### Automated testing
Pass the added automated test

#### Manual testing
Steps:
1. deploying the CloudFormation Macro stack then the app stack.
2. Execute the state machine

Result:
1. The state machine has the expected tags
<img width="1136" alt="image" src="https://github.com/user-attachments/assets/b9a524db-40cc-4f52-9e79-af35723bdddd" />
2. The executions show up in Datadog app
<img width="1046" alt="image" src="https://github.com/user-attachments/assets/04f22af0-0c1a-4326-9767-372c2658d582" />

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
