### PR TITLE
[Step Function] 7.1 Add skeleton code for merging traces

### DIFF
--- a/serverless/src/step_function/span-link.ts
+++ b/serverless/src/step_function/span-link.ts
@@ -1,0 +1,108 @@
+import { Resources } from "../common/types";
+import { StateMachine } from "./types";
+import log from "loglevel";
+
+// Lambda invocation step's Payload field
+export type LambdaStepPayload = {
+  "Execution.$"?: any;
+  Execution?: any;
+  "State.$"?: any;
+  State?: any;
+  "StateMachine.$"?: any;
+  StateMachine?: any;
+};
+
+export interface StateMachineDefinition {
+  States: { [key: string]: StateMachineState };
+}
+
+// A state in the Step Function definition
+export interface StateMachineState {
+  Resource?: string;
+  Parameters?: {
+    FunctionName?: string;
+    // Payload field for Lambda invocation steps
+    Payload?: string | LambdaStepPayload;
+    "Payload.$"?: string;
+  };
+  Next?: string;
+  End?: boolean;
+}
+
+/**
+ * Modify the defintion of Lambda and Step Function invocation steps to allow merging the current Step Function's
+ * traces with its downstream Lambda or Step Functions' traces.
+ *
+ * In case of unsupported cases, this function will log a warning instead of throwing an error
+ * because merging traces is not a critical step of instrumenting Step Functions.
+ */
+export function mergeTracesWithDownstream(resources: Resources, stateMachine: StateMachine): boolean {
+  log.debug(`Setting up trace merging for State Machine ${stateMachine.resourceKey}`);
+
+  let definitionString = stateMachine.properties.DefinitionString;
+  if (definitionString === undefined) {
+    log.warn(
+      `State machine ${stateMachine.resourceKey} does not have a definition string. ` +
+        getUnsupportedCaseErrorMessage("Lambda or Step Function"),
+    );
+    return false;
+  }
+
+  // Step 1: Parse definition object from definition string
+  let definitionObj: StateMachineDefinition;
+
+  // If definitionString is an object, we require it to be {"Fn::Sub": string}
+  try {
+    definitionObj = parseDefinitionObject(definitionString);
+  } catch (error) {
+    log.warn(error + " " + getUnsupportedCaseErrorMessage("Lambda or Step Function"));
+    return false;
+  }
+
+  // Step 2: Mutate the definition object
+  const states = definitionObj.States;
+  for (const [stepName, step] of Object.entries(states)) {
+    // Only inject context into Lambda invocation steps
+    if (isLambdaInvocationStep(step?.Resource)) {
+      try {
+        updateDefinitionForLambdaInvocationStep(stepName, step);
+      } catch (error) {
+        log.warn(error + " " + getUnsupportedCaseErrorMessage("Lambda"));
+        return false;
+      }
+    }
+  }
+
+  // Step 3: Convert definition object back into definition string
+  definitionString = { "Fn::Sub": JSON.stringify(definitionObj) };
+
+  // Step 4: Write back the definition string to the state machine
+  stateMachine.properties.DefinitionString = definitionString;
+  return true;
+}
+
+function parseDefinitionObject(definitionString: { "Fn::Sub": string }): StateMachineDefinition {
+  const unparsedDefinition = definitionString["Fn::Sub"];
+  const definitionObj: StateMachineDefinition = JSON.parse(unparsedDefinition);
+  return definitionObj;
+}
+
+function isLambdaInvocationStep(resource: string | undefined): boolean {
+  return (
+    resource !== undefined &&
+    (resource?.startsWith("arn:aws:states:::lambda:invoke") || resource?.startsWith("arn:aws:lambda"))
+  );
+}
+
+function updateDefinitionForLambdaInvocationStep(stepName: string, state: StateMachineState): void {
+  // TODO: Replace this dummy implementation with the actual implementation
+  state.Parameters = { FunctionName: "MyLambdaFunction" };
+}
+
+function getUnsupportedCaseErrorMessage(resourceType: string): string {
+  return `Step Functions Context Object injection skipped. Your Step Function's trace will \
+not be merged with downstream ${resourceType}'s traces. To manually merge these traces, check out \
+https://docs.datadoghq.com/serverless/step_functions/troubleshooting/. You may also open a feature request in \
+https://github.com/DataDog/datadog-cloudformation-macro. In the feature request, please include the \
+definition of your Lambda step or Step Function invocation step.\n`;
+}

--- a/serverless/src/step_function/step_function.ts
+++ b/serverless/src/step_function/step_function.ts
@@ -5,6 +5,7 @@ import { Configuration } from "./env";
 import { setUpLogging } from "./log";
 import { addForwarder } from "./forwarder";
 import { addTags } from "./tags";
+import { mergeTracesWithDownstream } from "./span-link";
 
 const STATE_MACHINE_RESOURCE_TYPE = "AWS::StepFunctions::StateMachine";
 
@@ -36,6 +37,8 @@ function instrumentStateMachine(resources: Resources, config: Configuration, sta
   }
 
   addTags(config, stateMachine);
+
+  mergeTracesWithDownstream(resources, stateMachine);
 }
 
 export function findStateMachines(resources: Resources): StateMachine[] {

--- a/serverless/src/step_function/types.ts
+++ b/serverless/src/step_function/types.ts
@@ -12,6 +12,9 @@ export interface StateMachineProperties {
   LoggingConfiguration?: LoggingConfiguration;
   RoleArn?: string | { [key: string]: any };
   Tags?: { Key: string; Value: string }[];
+  // This also covers the "!Sub" shorthand in CloudFormation template. "!Sub" will be
+  // replaced with "Fn::Sub" by AWS CloudFormation template processing and the
+  // CloudFormation Macro will get "Fn::Sub".
   DefinitionString?: { "Fn::Sub": string };
 }
 

--- a/serverless/src/step_function/types.ts
+++ b/serverless/src/step_function/types.ts
@@ -12,6 +12,7 @@ export interface StateMachineProperties {
   LoggingConfiguration?: LoggingConfiguration;
   RoleArn?: string | { [key: string]: any };
   Tags?: { Key: string; Value: string }[];
+  DefinitionString?: { "Fn::Sub": string };
 }
 
 // Matches AWS::StepFunctions::StateMachine LoggingConfiguration

--- a/serverless/test/step_function/span-link.spec.ts
+++ b/serverless/test/step_function/span-link.spec.ts
@@ -1,0 +1,58 @@
+import {
+  mergeTracesWithDownstream,
+  StateMachineState,
+  StateMachineDefinition,
+} from "../../src/step_function/span-link";
+import { Resources } from "common/types";
+import { StateMachine } from "../../src/step_function/types";
+
+describe("Step Function Span Link", () => {
+  describe("mergeTracesWithDownstream", () => {
+    let resources: Resources;
+    let stateMachineDefinition: StateMachineDefinition;
+    let stateMachine: StateMachine;
+    const stateMachineKey = "MyStateMachine";
+
+    beforeEach(() => {
+      resources = {};
+      stateMachineDefinition = {
+        States: {
+          HelloFunction: {
+            Type: "Task",
+            Resource: "arn:aws:states:::lambda:invoke",
+            End: true,
+          } as StateMachineState,
+        },
+      };
+      stateMachine = {
+        resourceKey: stateMachineKey,
+        properties: {},
+      };
+    });
+
+    it('succeeds when definitionString is {"Fn::Sub": string}', () => {
+      stateMachine.properties.DefinitionString = {
+        "Fn::Sub": JSON.stringify(stateMachineDefinition),
+      };
+      const isTraceMergingSetUp = mergeTracesWithDownstream(resources, stateMachine);
+      expect(isTraceMergingSetUp).toBe(true);
+
+      const updatedDefinition = JSON.parse(stateMachine.properties.DefinitionString!["Fn::Sub"]);
+      expect(updatedDefinition.States["HelloFunction"].Parameters).toStrictEqual({ FunctionName: "MyLambdaFunction" });
+    });
+
+    it("fails when state machine's definition is not found", () => {
+      // stateMachine has no DefinitionString field
+      const isTraceMergingSetUp = mergeTracesWithDownstream(resources, stateMachine);
+      expect(isTraceMergingSetUp).toBe(false);
+    });
+
+    it("fails when state machine's DefinitionString is invalid", () => {
+      stateMachine.properties.DefinitionString = {
+        "Fn::Sub": "{",
+      };
+      const isTraceMergingSetUp = mergeTracesWithDownstream(resources, stateMachine);
+      expect(isTraceMergingSetUp).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
### Context of this PR series

Right now the Datadog Serverless CloudFormation Macro only supports instrumenting Lambda functions. This series of PRs makes it also support instrumenting Step Functions.

Instead of merging every PR into main branch, I'm going to merge them into a feature branch `yiming.luo/step-function` to avoid releasing partial support for step functions

### What does this PR do?
Adds skeleton code to prepare for setting up trace merging.

### Limitations
#### 1. State Machine definition format
This PR assumes the state machine's definition is in this format:
```
MyStateMachine:
    Properties:
      DefinitionString: !Sub | <JSON string>
```
However, there are many other ways to define the state machine's definition, e.g.
```
MyStateMachine:
    Properties:
      DefinitionString: <JSON string>
```
```
MyStateMachine:
    Properties:
      DefinitionString:
        !Sub
          - |-
            <JSON string>
          - <An object specifying substitutions>
```
```
MyStateMachine:
    Properties:
      Definition: <an object>
```
```
MyStateMachine:
    Properties:
      DefinitionS3Location: <S3Location>
```
See more in [AWS::StepFunctions::StateMachine](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-stepfunctions-statemachine.html#cfn-stepfunctions-statemachine-definition).

I'll handle some of these cases in future PRs.

#### 2. Trace merging implementation
The function `updateDefinitionForLambdaInvocationStep()` has a dummy implementation to make it easier to write tests because I didn't find a way to mock it. I will update the function and tests in future PRs.

<!--- A brief description of the change being made with this pull request. --->

### Motivation

Trace merging is one step of instrumenting a state machine.

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
#### Automated testing
Pass the added automated test

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Notes
Lots of code is copied from https://github.com/DataDog/serverless-plugin-datadog/blob/aae5222f67409ed670d2f079e181f41efadb9003/src/step-functions-helper.ts. Thanks @agocs and @kimi-p for previous work.

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
