### PR TITLE
[Step Function] 7.2 Handle the case when definition is a string

### DIFF
--- a/serverless/src/step_function/types.ts
+++ b/serverless/src/step_function/types.ts
@@ -7,6 +7,8 @@ export interface StateMachine extends TaggableResource {
   resourceKey: string;
 }
 
+export type DefinitionString = string | { "Fn::Sub": string };
+
 // Necessary fields from AWS::StepFunctions::StateMachine's Properties field
 export interface StateMachineProperties {
   LoggingConfiguration?: LoggingConfiguration;
@@ -15,7 +17,7 @@ export interface StateMachineProperties {
   // This also covers the "!Sub" shorthand in CloudFormation template. "!Sub" will be
   // replaced with "Fn::Sub" by AWS CloudFormation template processing and the
   // CloudFormation Macro will get "Fn::Sub".
-  DefinitionString?: { "Fn::Sub": string };
+  DefinitionString?: DefinitionString;
 }
 
 // Matches AWS::StepFunctions::StateMachine LoggingConfiguration

--- a/serverless/test/step_function/span-link.spec.ts
+++ b/serverless/test/step_function/span-link.spec.ts
@@ -30,7 +30,16 @@ describe("Step Function Span Link", () => {
       };
     });
 
-    it('succeeds when definitionString is {"Fn::Sub": string}', () => {
+    it("Case 1: succeeds when definitionString is a string", () => {
+      stateMachine.properties.DefinitionString = JSON.stringify(stateMachineDefinition);
+      const isTraceMergingSetUp = mergeTracesWithDownstream(resources, stateMachine);
+      expect(isTraceMergingSetUp).toBe(true);
+
+      const updatedDefinition = JSON.parse(stateMachine.properties.DefinitionString);
+      expect(updatedDefinition.States["HelloFunction"].Parameters).toStrictEqual({ FunctionName: "MyLambdaFunction" });
+    });
+
+    it('Case 2: succeeds when definitionString is {"Fn::Sub": string}', () => {
       stateMachine.properties.DefinitionString = {
         "Fn::Sub": JSON.stringify(stateMachineDefinition),
       };


### PR DESCRIPTION
### Context of this PR series

Right now the Datadog Serverless CloudFormation Macro only supports instrumenting Lambda functions. This series of PRs makes it also support instrumenting Step Functions.

Instead of merging every PR into main branch, I'm going to merge them into a feature branch `yiming.luo/step-function` to avoid releasing partial support for step functions

### Context of this PR
There are many formats the state machine's `definitionString` field can take. See https://github.com/DataDog/datadog-cloudformation-macro/pull/158

### What does this PR do?
Handles the case when the state machine's `definitionString` field is in this format:
```
MyStateMachine:
    Properties:
      DefinitionString: <JSON string>
```

<!--- A brief description of the change being made with this pull request. --->

### Motivation

Trace merging is one step of instrumenting a state machine.

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
#### Automated testing
Pass the added automated test

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Notes

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
