### PR TITLE
[Step Function] 7.3 Handle definition is {"Fn::Sub": array}

### DIFF
--- a/serverless/src/step_function/types.ts
+++ b/serverless/src/step_function/types.ts
@@ -7,7 +7,7 @@ export interface StateMachine extends TaggableResource {
   resourceKey: string;
 }
 
-export type DefinitionString = string | { "Fn::Sub": string };
+export type DefinitionString = string | { "Fn::Sub": string | (string | object)[] };
 
 // Necessary fields from AWS::StepFunctions::StateMachine's Properties field
 export interface StateMachineProperties {

--- a/serverless/test/step_function/span-link.spec.ts
+++ b/serverless/test/step_function/span-link.spec.ts
@@ -46,7 +46,20 @@ describe("Step Function Span Link", () => {
       const isTraceMergingSetUp = mergeTracesWithDownstream(resources, stateMachine);
       expect(isTraceMergingSetUp).toBe(true);
 
-      const updatedDefinition = JSON.parse(stateMachine.properties.DefinitionString!["Fn::Sub"]);
+      const updatedDefinitionString = stateMachine.properties.DefinitionString as { "Fn::Sub": string };
+      const updatedDefinition = JSON.parse(updatedDefinitionString["Fn::Sub"]);
+      expect(updatedDefinition.States["HelloFunction"].Parameters).toStrictEqual({ FunctionName: "MyLambdaFunction" });
+    });
+
+    it('Case 3: succeeds when definitionString is {"Fn::Sub": (string | object)[]}', () => {
+      stateMachine.properties.DefinitionString = {
+        "Fn::Sub": [JSON.stringify(stateMachineDefinition), {}],
+      };
+      const isTraceMergingSetUp = mergeTracesWithDownstream(resources, stateMachine);
+      expect(isTraceMergingSetUp).toBe(true);
+
+      const updatedDefinitionString = stateMachine.properties.DefinitionString as { "Fn::Sub": (string | object)[] };
+      const updatedDefinition = JSON.parse(updatedDefinitionString["Fn::Sub"][0] as string);
       expect(updatedDefinition.States["HelloFunction"].Parameters).toStrictEqual({ FunctionName: "MyLambdaFunction" });
     });
 


### PR DESCRIPTION
### Context of this PR series

Right now the Datadog Serverless CloudFormation Macro only supports instrumenting Lambda functions. This series of PRs makes it also support instrumenting Step Functions.

Instead of merging every PR into main branch, I'm going to merge them into a feature branch `yiming.luo/step-function` to avoid releasing partial support for step functions

### Context of this PR
There are many formats the state machine's `definitionString` field can take. See https://github.com/DataDog/datadog-cloudformation-macro/pull/158

### What does this PR do?
Handles the case when the state machine's `definitionString` field is in this format:
```
MyStateMachine:
    Properties:
      DefinitionString:
        !Sub
          - |-
            <JSON string>
          - <An object specifying substitutions> (optional)
```

<!--- A brief description of the change being made with this pull request. --->


<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
#### Automated testing
Pass the added automated test

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Notes

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
