### PR TITLE
[Step Function] 7.6 Handle the case when definition is an object

### DIFF
--- a/serverless/src/step_function/types.ts
+++ b/serverless/src/step_function/types.ts
@@ -18,6 +18,7 @@ export interface StateMachineProperties {
   // replaced with "Fn::Sub" by AWS CloudFormation template processing and the
   // CloudFormation Macro will get "Fn::Sub".
   DefinitionString?: DefinitionString;
+  Definition?: StateMachineDefinition;
 }
 
 // Matches AWS::StepFunctions::StateMachine LoggingConfiguration
@@ -39,4 +40,39 @@ export interface CloudWatchLogsLogGroup {
     | {
         "Fn::GetAtt": string[];
       };
+}
+
+export interface StateMachineDefinition {
+  States: { [key: string]: StateMachineState };
+}
+
+// Lambda invocation step's Payload field
+export type LambdaStepPayload = {
+  "Execution.$"?: any;
+  Execution?: any;
+  "State.$"?: any;
+  State?: any;
+  "StateMachine.$"?: any;
+  StateMachine?: any;
+};
+
+// Step Function invocation step's Input field
+export type StateMachineStateInput = {
+  "CONTEXT.$"?: string;
+  CONTEXT?: string;
+};
+
+// A state in the Step Function definition
+export interface StateMachineState {
+  Resource?: string;
+  Parameters?: {
+    FunctionName?: string;
+    // Payload field for Lambda invocation steps
+    Payload?: string | LambdaStepPayload;
+    "Payload.$"?: string;
+    // Input field for Step Function invocation steps
+    Input?: string | StateMachineStateInput;
+  };
+  Next?: string;
+  End?: boolean;
 }

--- a/serverless/test/step_function/span-link.spec.ts
+++ b/serverless/test/step_function/span-link.spec.ts
@@ -1,12 +1,10 @@
 import {
   mergeTracesWithDownstream,
-  StateMachineState,
-  StateMachineDefinition,
   updateDefinitionForLambdaInvocationStep,
   updateDefinitionForStepFunctionInvocationStep,
 } from "../../src/step_function/span-link";
 import { Resources } from "common/types";
-import { StateMachine } from "../../src/step_function/types";
+import { StateMachine, StateMachineState, StateMachineDefinition } from "../../src/step_function/types";
 
 describe("Step Function Span Link", () => {
   describe("mergeTracesWithDownstream", () => {
@@ -70,6 +68,17 @@ describe("Step Function Span Link", () => {
       const updatedDefinitionString = stateMachine.properties.DefinitionString as { "Fn::Sub": (string | object)[] };
       const updatedDefinition = JSON.parse(updatedDefinitionString["Fn::Sub"][0] as string);
       expect(updatedDefinition.States["HelloFunction"].Parameters["Payload.$"]).toEqual(
+        "$$['Execution', 'State', 'StateMachine']",
+      );
+    });
+
+    it("Case 4: succeeds when definition field is an object", () => {
+      stateMachine.properties.Definition = stateMachineDefinition;
+      const isTraceMergingSetUp = mergeTracesWithDownstream(resources, stateMachine);
+      expect(isTraceMergingSetUp).toBe(true);
+
+      const updatedDefinition = stateMachine.properties.Definition;
+      expect(updatedDefinition.States["HelloFunction"].Parameters!["Payload.$"]).toEqual(
         "$$['Execution', 'State', 'StateMachine']",
       );
     });


### PR DESCRIPTION
### Context of this PR series

Right now the Datadog Serverless CloudFormation Macro only supports instrumenting Lambda functions. This series of PRs makes it also support instrumenting Step Functions.

Instead of merging every PR into main branch, I'm going to merge them into a feature branch `yiming.luo/step-function` to avoid releasing partial support for step functions

### Context of this PR
There are many formats the state machine's `definitionString` field can take. See https://github.com/DataDog/datadog-cloudformation-macro/pull/158

### What does this PR do?
Handles the case when the state machine's `definitionString` field is in this format:
```
MyStateMachine:
    Properties:
      Definition: <an object>
```

It involves moving some commonly-used interfaces from `step_function/span-link.ts` to `step_function/types.ts`.
<!--- A brief description of the change being made with this pull request. --->


<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
#### Automated testing
Pass the added automated test

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Notes

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
