### PR TITLE
[Step Function] 8.1 Fix subscription filter creation failure

### DIFF
--- a/serverless/src/step_function/forwarder.ts
+++ b/serverless/src/step_function/forwarder.ts
@@ -11,9 +11,10 @@ export const SUBSCRIPTION_FILTER_PREFIX = "LogGroupDatadogSubscriptionFilter";
  */
 export function addForwarder(resources: Resources, config: Configuration, stateMachine: StateMachine): void {
   log.debug(`Subscribing the forwarder to the log group...`);
-  const logGroup = findLogGroup(resources, stateMachine);
+  const [logGroupKey, logGroup] = findLogGroup(resources, stateMachine);
   const subscriptionFilter = {
     Type: "AWS::Logs::SubscriptionFilter",
+    DependsOn: logGroupKey,
     Properties: {
       LogGroupName: logGroup.Properties.LogGroupName,
       DestinationArn: config.stepFunctionForwarderArn,

--- a/serverless/src/step_function/log.ts
+++ b/serverless/src/step_function/log.ts
@@ -168,8 +168,9 @@ export const buildLogGroupName = (stateMachine: StateMachine, env: string | unde
  *    "Fn::GetAtt": ["MyStateMachineLogGroup", "Arn"]
  *    which is the most common way of referencing a log group.
  * We can add support for other cases when users request it.
+ * @returns [logGroupKey, logGroup]
  */
-export function findLogGroup(resources: Resources, stateMachine: StateMachine): LogGroup {
+export function findLogGroup(resources: Resources, stateMachine: StateMachine): [string, LogGroup] {
   const logConfig = stateMachine.properties.LoggingConfiguration;
 
   if (!logConfig?.Destinations) {
@@ -189,5 +190,5 @@ export function findLogGroup(resources: Resources, stateMachine: StateMachine): 
   }
   const logGroupKey = logGroupArn[FN_GET_ATT][0];
   const logGroup = resources[logGroupKey];
-  return logGroup;
+  return [logGroupKey, logGroup];
 }

--- a/serverless/test/step_function/forwarder.spec.ts
+++ b/serverless/test/step_function/forwarder.spec.ts
@@ -13,17 +13,21 @@ describe("addForwarder", () => {
     const stateMachine = {
       resourceKey: "MyStateMachine",
     } as any;
-    (findLogGroup as jest.Mock).mockReturnValue({
-      Properties: {
-        LogGroupName: "/aws/lambda/my-function",
+    (findLogGroup as jest.Mock).mockReturnValue([
+      "MyStateMachineLogGroup",
+      {
+        Properties: {
+          LogGroupName: "/aws/lambda/my-function",
+        },
       },
-    });
+    ]);
 
     addForwarder(resources, config, stateMachine);
 
     const subscriptionFilterKey = stateMachine.resourceKey + SUBSCRIPTION_FILTER_PREFIX;
     expect(resources[subscriptionFilterKey]).toEqual({
       Type: "AWS::Logs::SubscriptionFilter",
+      DependsOn: "MyStateMachineLogGroup",
       Properties: {
         LogGroupName: "/aws/lambda/my-function",
         DestinationArn: config.stepFunctionForwarderArn,

--- a/serverless/test/step_function/log.spec.ts
+++ b/serverless/test/step_function/log.spec.ts
@@ -174,7 +174,8 @@ describe("findLogGroup", () => {
       },
     };
 
-    const logGroup = findLogGroup(resources, stateMachine);
+    const [logGroupKey, logGroup] = findLogGroup(resources, stateMachine);
+    expect(logGroupKey).toBe("MyStateMachineLogGroup");
     expect(logGroup.Type).toBe("AWS::Logs::LogGroup");
     expect(logGroup.Properties.LogGroupName).toBe("/aws/vendedlogs/states/MyStateMachine-Logs-dev");
   });


### PR DESCRIPTION
### Context of this PR series

Right now the Datadog Serverless CloudFormation Macro only supports instrumenting Lambda functions. This series of PRs makes it also support instrumenting Step Functions.

Instead of merging every PR into main branch, I'm going to merge them into a feature branch `yiming.luo/step-function` to avoid releasing partial support for step functions

### Problem this PR solves

When I deploy an application stack that includes a step function and uses our CloudFormation Macro, deployment fails when creating the log group subscription filter. It says the log group is not found.

<!--- What inspired you to submit this pull request? --->

### What does this PR do?
Add a `DependsOn` field to specify that the subscription filter depends on the log group.

### Testing Guidelines
#### Automated testing
Deploy the CloudFormation Macro stack then the application stack. The application stack could deploy successfully. Both the log group and the subscription filter were created.

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
