### PR TITLE
[Step Function] 7.7 Handle: definitionString uses Fn::Join

### DIFF
--- a/serverless/src/step_function/types.ts
+++ b/serverless/src/step_function/types.ts
@@ -7,7 +7,10 @@ export interface StateMachine extends TaggableResource {
   resourceKey: string;
 }
 
-export type DefinitionString = string | { "Fn::Sub": string | (string | object)[] };
+export type DefinitionString =
+  | string
+  | { "Fn::Sub": string | (string | object)[] }
+  | { "Fn::Join": [string, string[]] };
 
 // Necessary fields from AWS::StepFunctions::StateMachine's Properties field
 export interface StateMachineProperties {


### PR DESCRIPTION
### Context of this PR series

Right now the Datadog Serverless CloudFormation Macro only supports instrumenting Lambda functions. This series of PRs makes it also support instrumenting Step Functions.

Instead of merging every PR into main branch, I'm going to merge them into a feature branch `yiming.luo/step-function` to avoid releasing partial support for step functions

### Context of this PR
There are many formats the state machine's `definitionString` field can take. See https://github.com/DataDog/datadog-cloudformation-macro/pull/158

### What does this PR do?
Handles the case when the state machine's `definitionString` field is in this format:
```
MyStateMachine:
    Properties:
      DefinitionString:
        Fn::Join:
          - "\n"
          - <JSON lines of definition>
```

This is what our CloudFormation Macro will get when the user uses resource type `AWS::Serverless::StateMachine` and use its Definition field to define the state machine, e.g.:
```
  MySAMHelloStateMachine2:
    Type: AWS::Serverless::StateMachine
    Properties:
      Role: !GetAtt StepFunctionsExecutionRole2.Arn
      Definition:
        Comment: "A state machine that calls another state machine."
        StartAt: "Invoke Step Function"
        States:
          Invoke Step Function:
            Type: Task
            Resource: "arn:aws:states:::states:startExecution"
            Parameters:
              StateMachineArn: !GetAtt MySAMHelloStateMachine2.Arn
            End: true
```

See more about how SAM Translator translates the SAM resource type `AWS::Serverless::StateMachine` into a lower level CloudFormation resource type `AWS::StepFunctions::StateMachine` https://github.com/aws/serverless-application-model/blob/d50ce3caff3ef1e590b8b806a02bfe6f8edd2816/samtranslator/model/stepfunctions/generators.py#L206-L219
<!--- A brief description of the change being made with this pull request. --->

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
#### Automated testing
Pass the added automated test

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Notes

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
