### PR TITLE
Change dockerfile to trigger ci image build in gitlab 

### DIFF
--- a/serverless/Dockerfile
+++ b/serverless/Dockerfile
@@ -4,6 +4,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     wget curl gnupg unzip zip jq uuid-runtime
 
 # Install AWS CLI.
+
 RUN  curl 'https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip' -o "awscliv2.zip"
 RUN unzip awscliv2.zip && ./aws/install
 


### PR DESCRIPTION
### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

This PR will slightly modify the Dockerfile so that it'll trigger the CI image to build in the gitlab pipeline. Here's the relevant PR for it: https://github.com/DataDog/serverless-ci/pull/3 and [comment](https://github.com/DataDog/serverless-ci/pull/3#discussion_r1965678216)

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
