### PR TITLE
Fix grep logic

### DIFF
--- a/serverless/release.sh
+++ b/serverless/release.sh
@@ -48,7 +48,7 @@ echo "$CI_PIPELINE_SOURCE"
 
 if [ "$PROD_RELEASE" = true ] ; then
     if [ -z "$CI_COMMIT_TAG" ]; then
-        printf "[Error] No CI_COMMIT_TAG found. Create a new tag for this prod release in Repo first!\n"
+        printf "[Error] No CI_COMMIT_TAG found. Create a new tag for this prod release in repo first!\n"
         printf "Exiting script...\n"
         exit 1
     else


### PR DESCRIPTION
### What does this PR do?

With the version of grep being used in the builder, using `\d` to match number doesn't work. This PR is to change it to instead use `[0-9]` as per Yiming's investigation
