### PR TITLE
Generate GH token instead of using PAT

### DIFF
--- a/serverless/tools/generate_jwt.sh
+++ b/serverless/tools/generate_jwt.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -o pipefail
+
+client_id=$1 # Client ID as first argument
+
+pem=$( cat $2 ) # file path of the private key as second argument
+
+now=$(date +%s)
+iat=$((${now} - 60)) # Issues 60 seconds in the past
+exp=$((${now} + 600)) # Expires 10 minutes in the future
+
+b64enc() { openssl base64 | tr -d '=' | tr '/+' '_-' | tr -d '\n'; }
+
+header_json='{
+    "typ":"JWT",
+    "alg":"RS256"
+}'
+# Header encode
+header=$( echo -n "${header_json}" | b64enc )
+
+payload_json="{
+    \"iat\":${iat},
+    \"exp\":${exp},
+    \"iss\":\"${client_id}\"
+}"
+# Payload encode
+payload=$( echo -n "${payload_json}" | b64enc )
+
+# Signature
+header_payload="${header}"."${payload}"
+signature=$(
+    openssl dgst -sha256 -sign <(echo -n "${pem}") \
+    <(echo -n "${header_payload}") | b64enc
+)
+
+# Create JWT
+JWT="${header_payload}"."${signature}"
+echo "$JWT"

--- a/serverless/tools/get_secrets.sh
+++ b/serverless/tools/get_secrets.sh
@@ -7,7 +7,17 @@
 
 set -e
 
-export GH_TOKEN=$(vault kv get -field="prod_publish_token" kv/k8s/gitlab-runner/datadog-cloudformation-macro/secrets)
+# Get the JWT
+export GH_APP_ID=$(vault kv get -field="gh_app_id" kv/k8s/gitlab-runner/datadog-cloudformation-macro/secrets)
+export GH_PRIVATE_KEY=$(vault kv get -field="gh_private_key" kv/k8s/gitlab-runner/datadog-cloudformation-macro/secrets)
+
+# Write private key to a temporary file
+PRIVATE_KEY_FILE=$(mktemp)
+echo "$GH_PRIVATE_KEY" > "$PRIVATE_KEY_FILE"
+
+# Get the GH token
+export GH_TOKEN=$(bash serverless/tools/generate_jwt.sh $GH_APP_ID $PRIVATE_KEY_FILE)
+
 
 if [ -z "$EXTERNAL_ID_NAME" ]; then
     printf "[Error] No EXTERNAL_ID_NAME found.\n"


### PR DESCRIPTION
### What does this PR do?

Generate the GH token from an app key instead of using someone's PAT.

### Motivation

* JIRA: https://datadoghq.atlassian.net/browse/SVLS-6933

### Testing Guidelines

* I tried it out in [gitlab](https://gitlab.ddbuild.io/DataDog/datadog-cloudformation-macro/-/jobs/981892383#L59) with an extra API call.  Note this isn't doing the release but a different call I added
* I'll try out the CFN macro release after this is merged

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
