### PR TITLE
Use JWT to get GH Token

### DIFF
--- a/serverless/release.sh
+++ b/serverless/release.sh
@@ -71,7 +71,7 @@ if [ "$PROD_RELEASE" = true ] ; then
     git remote set-url origin https://github.com/DataDog/datadog-cloudformation-macro.git
 
     echo "Checking git auth status"
-    gh auth status 
+    gh auth status
 
     git config --global user.name "gitlab-actions[bot]"
     git config --global user.email "gitlab-actions[bot]@users.noreply.github.com"

--- a/serverless/tools/get_secrets.sh
+++ b/serverless/tools/get_secrets.sh
@@ -10,13 +10,20 @@ set -e
 # Get the JWT
 export GH_APP_ID=$(vault kv get -field="gh_app_id" kv/k8s/gitlab-runner/datadog-cloudformation-macro/secrets)
 export GH_PRIVATE_KEY=$(vault kv get -field="gh_private_key" kv/k8s/gitlab-runner/datadog-cloudformation-macro/secrets)
+export GH_INSTALLATION_ID=$(vault kv get -field="gh_installation_id" kv/k8s/gitlab-runner/datadog-cloudformation-macro/secrets)
+
 
 # Write private key to a temporary file
 PRIVATE_KEY_FILE=$(mktemp)
 echo "$GH_PRIVATE_KEY" > "$PRIVATE_KEY_FILE"
 
 # Get the GH token
-export GH_TOKEN=$(bash serverless/tools/generate_jwt.sh $GH_APP_ID $PRIVATE_KEY_FILE)
+export JWT_TOKEN=$(bash serverless/tools/generate_jwt.sh $GH_APP_ID $PRIVATE_KEY_FILE)
+
+export GH_TOKEN=$(curl -s -X POST \
+    -H "Authorization: Bearer $JWT_TOKEN" \
+    -H "Accept: application/vnd.github.v3+json" \
+    "https://api.github.com/app/installations/$GH_INSTALLATION_ID/access_tokens" | jq -r '.token')
 
 
 if [ -z "$EXTERNAL_ID_NAME" ]; then


### PR DESCRIPTION
### What does this PR do?

Previously I thought that we could use the JWT to as the token for github, but we actually need to use that to get the github token, and then everything else should work the same.  I tried this by checking the auth status on a test run, and it seems to work.

### Motivation

Unblock releases

### Testing Guidelines

See `gh auth status` pass [here](https://gitlab.ddbuild.io/DataDog/datadog-cloudformation-macro/-/jobs/988917219#L57)

```
github.com
  ✓ Logged in to github.com account datadog-cloudformation-macro-bot[bot] (GH_TOKEN)
  - Active account: true
  - Git operations protocol: https
  - Token: ghs_************************************
```



### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
