### PR TITLE
Add x-access-token to GH token in URL

### DIFF
--- a/serverless/release.sh
+++ b/serverless/release.sh
@@ -100,7 +100,7 @@ if [ "$PROD_RELEASE" = true ] ; then
     git commit -m "Bump version from ${CURRENT_VERSION} to ${VERSION}"
     # git push origin main
     echo "pushing to remote branch"
-    git remote set-url origin https://$GH_TOKEN@github.com/DataDog/datadog-cloudformation-macro.git
+    git remote set-url origin https://x-access-token:$GH_TOKEN@github.com/DataDog/datadog-cloudformation-macro.git
     git push origin main
 
     # Create a github release


### PR DESCRIPTION
### What does this PR do?
Add the x-access-token prefix to the GH token when setting the remote origin, since the token is generated from a JWT and not someone's PAT it needs to have this prefix.

### Motivation
Unblock releases


### Testing Guidelines
Brought this command up to the top for a sandbox test release and it worked, ran into some other issues when pushing but I think that's just because I didn't setup the rest of it correctly, and I'm hoping that this will push to main in the context of the rest of the release script.

### Additional Notes
* Github docs: https://docs.github.com/en/enterprise-cloud@latest/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-as-a-github-app-installation#about-authentication-as-a-github-app-installation
### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
