### PR TITLE
chore: drop node 20, add node 26 to CI matrix

### DIFF
--- a/.github/workflows/build_serverless.yml
+++ b/.github/workflows/build_serverless.yml
@@ -92,7 +92,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Node ${{ matrix.node-version }}
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/build_serverless.yml
+++ b/.github/workflows/build_serverless.yml
@@ -82,11 +82,10 @@ jobs:
       run:
         working-directory: serverless
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.node-version == 26 }}
 
     strategy:
       matrix:
-        node-version: [22, 24, 26]
+        node-version: [22, 24]
 
     steps:
       - name: Checkout

--- a/.github/workflows/build_serverless.yml
+++ b/.github/workflows/build_serverless.yml
@@ -82,6 +82,7 @@ jobs:
       run:
         working-directory: serverless
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.node-version == 26 }}
 
     strategy:
       matrix:

--- a/.github/workflows/build_serverless.yml
+++ b/.github/workflows/build_serverless.yml
@@ -85,7 +85,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20, 22, 24]
+        node-version: [22, 24, 26]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

- Removes Node 20 from the CI test matrix (min supported is now Node 22)

## Test plan

- [x] CI passes on Node 22 and 24