### PR TITLE
chore: fix missing node_modules in lambda zip

### DIFF
--- a/.github/workflows/build_serverless.yml
+++ b/.github/workflows/build_serverless.yml
@@ -77,6 +77,9 @@ jobs:
       - name: Build
         run: yarn build
 
+      - name: Verify Lambda bundle
+        run: cd dist && node -e "require('./src/index.js')"
+
   test:
     defaults:
       run:

--- a/serverless/package.json
+++ b/serverless/package.json
@@ -8,7 +8,7 @@
   "main": "dist/src/index.js",
   "scripts": {
     "build": "tsc",
-    "postbuild": "cp package.json dist/package.json && cd dist && npm install --omit=dev",
+    "postbuild": "cp package.json dist/package.json && npm pkg delete packageManager --prefix dist && npm install --omit=dev --prefix dist",
     "test": "jest",
     "test:watch": "jest --watch",
     "coverage": "jest --coverage",


### PR DESCRIPTION
### What does this PR do?

Fixes the `postbuild` script in `serverless/package.json` so that `dist/node_modules/` is correctly populated when building the Lambda zip in CI. Also adds a bundle verification step to GitHub Actions to catch this class of regression going forward.

### Motivation

v0.27.0 shipped a broken Lambda -- cold starts crash with `Cannot find module 'loglevel'` because `dist/node_modules/` is empty in the zip.

Root cause: PR #238 (yarn berry migration) changed `postbuild` to `cd dist && npm install --omit=dev`, and the copied `dist/package.json` carries `"packageManager": "yarn@4.12.0"`. In CI, Node 24's corepack sees that field and intercepts the `npm` call, so the install silently produces nothing. Locally, corepack isn't enforced, so the bug doesn't surface.

Fix: strip `packageManager` from `dist/package.json` before running npm, and use `--prefix dist` instead of `cd dist` so we stay in the `serverless/` directory where corepack has no opinion.

### Testing Guidelines

- `yarn build` in `serverless/` -- confirm `dist/node_modules/loglevel` and `dist/node_modules/@aws-sdk/` exist
- `cd dist && node -e "require('./src/index.js')"` -- should exit 0
- The new "Verify Lambda bundle" CI step will catch regressions automatically

### Additional Notes

The `packageManager` field stays in `serverless/package.json` (needed for yarn berry locally); it's only stripped from the copy written to `dist/`.

### Types of changes

- [x] Bug fix

### Check all that apply

- [x] This PR's description is comprehensive