### PR TITLE
chore: bump dockerfile to node 24

### DIFF
--- a/serverless/Dockerfile
+++ b/serverless/Dockerfile
@@ -13,8 +13,7 @@ RUN mkdir -p -m 755 /etc/apt/keyrings \
     && rm /tmp/githubcli-archive-keyring.gpg
 
 RUN mkdir -p /etc/apt/keyrings && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-# We are explicitly setting the node_20.x version for the installation
-RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_24.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
 RUN apt-get update && apt-get install nodejs -y
 RUN npm install --global yarn typescript
 


### PR DESCRIPTION
### What does this PR do?

Bumps the CI runner Dockerfile from Node 20 to Node 24, aligning it with the versions used in the GitHub Actions matrix (Node 20 was dropped in #243).

### Motivation

After #243 dropped Node 20 from the CI matrix, the Dockerfile was left behind on `node_20.x` with a now-stale comment. This keeps the release/CI environment consistent with the test matrix.

### Testing Guidelines

- CI should pass with the updated image.

### Additional Notes

No logic changes -- version bump only.

### Types of changes

- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive