### PR TITLE
[RELEASE] 0.27.2

### DIFF
--- a/serverless/package.json
+++ b/serverless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datadog-serverless-macro",
-  "version": "0.27.1",
+  "version": "0.27.2",
   "description": "Cloudformation macro to automatically instrument python, node, .net, ruby, and java functions with datadog tracing",
   "repository": "https://github.com/DataDog/datadog-cloudformation-macro",
   "author": "Datadog",

--- a/serverless/template.yml
+++ b/serverless/template.yml
@@ -4,7 +4,7 @@ Transform: AWS::Serverless-2016-10-31
 Mappings:
   Constants:
     DatadogServerlessMacro:
-      Version: 0.27.1
+      Version: 0.27.2
 
 Parameters:
   FunctionName:


### PR DESCRIPTION
### What does this PR do?

Bumps the macro version to 0.27.2. Picks up the fix from #248: the macro Lambda zip now actually contains `node_modules/`, so cold starts no longer crash with `Cannot find module 'loglevel'`.

### Motivation

v0.27.0 and v0.27.1 both shipped a broken zip (the `postbuild` install step never ran due to yarn berry not invoking arbitrary `pre`/`post` hooks). Customers on those versions hit `Runtime.ImportModuleError` on every macro invocation. See #242 for the customer report.

### Zip diff (proof the fix works)

| | v0.27.1 release zip | 0.27.2 staging zip (commit 4a10002d, CI-built) |
|---|---|---|
| Size | 128 KB | 3.68 MB compressed (9.1 MB uncompressed) |
| File count | 148 | 4274 |
| `node_modules/` present? | ❌ None | ✅ Yes (loglevel, @aws-sdk, @smithy, etc.) |
| `require('./src/index.js')` from extracted zip | ❌ `Cannot find module 'loglevel'` | ✅ Loads cleanly |

The staging zip from the GitLab pipeline run on #248 was confirmed at `s3://datadog-cloudformation-template-sandbox-staging/aws/serverless-macro-staging-zip/serverless-macro-4a10002d0c25010c04916588563fa99ff0902490.zip`.

### Testing Guidelines

- The fix and CI guard both shipped in #248
- After this version bump merges and is tagged, follow the usual prod release process: tag `serverless-macro-0.27.2` → run `release macro in prod` job → verify the new zip on GitHub releases has `node_modules/` before publishing the draft

### Types of changes

- [x] Bug fix
- [x] Release