### PR TITLE
Add ruby 4 support

### DIFF
--- a/serverless/src/lambda/layer.ts
+++ b/serverless/src/lambda/layer.ts
@@ -80,6 +80,7 @@ export const runtimeLookup: { [key: string]: RuntimeType } = {
   "ruby3.2": RuntimeType.RUBY,
   "ruby3.3": RuntimeType.RUBY,
   "ruby3.4": RuntimeType.RUBY,
+  "ruby4.0": RuntimeType.RUBY,
 };
 
 export const layerNameLookup: { [key in ArchitectureType]: { [key: string]: string } } = {
@@ -113,6 +114,7 @@ export const layerNameLookup: { [key in ArchitectureType]: { [key: string]: stri
     "ruby3.2": "Datadog-Ruby3-2",
     "ruby3.3": "Datadog-Ruby3-3",
     "ruby3.4": "Datadog-Ruby3-4",
+    "ruby4.0": "Datadog-Ruby4-0",
   },
   [ArchitectureType.ARM64]: {
     dotnet6: "dd-trace-dotnet-ARM",
@@ -141,6 +143,7 @@ export const layerNameLookup: { [key in ArchitectureType]: { [key: string]: stri
     "ruby3.2": "Datadog-Ruby3-2-ARM",
     "ruby3.3": "Datadog-Ruby3-3-ARM",
     "ruby3.4": "Datadog-Ruby3-4-ARM",
+    "ruby4.0": "Datadog-Ruby4-0-ARM",
   },
 };
 

--- a/serverless/test/lambda/layer.spec.ts
+++ b/serverless/test/lambda/layer.spec.ts
@@ -83,6 +83,7 @@ describe("findLambdas", () => {
       Ruby32Function: mockFunctionResource("ruby3.2", ["x86_64"]),
       Ruby33Function: mockFunctionResource("ruby3.3", ["x86_64"]),
       Ruby34Function: mockFunctionResource("ruby3.4", ["x86_64"]),
+      Ruby40Function: mockFunctionResource("ruby4.0", ["x86_64"]),
       GoFunction: mockFunctionResource("go1.10", ["x86_64"]),
       RefFunction: mockFunctionResource({ Ref: "ValueRef" }, ["arm64"]),
     };
@@ -126,6 +127,7 @@ describe("findLambdas", () => {
       mockLambdaFunction("Ruby32Function", "ruby3.2", RuntimeType.RUBY, "x86_64", ArchitectureType.x86_64),
       mockLambdaFunction("Ruby33Function", "ruby3.3", RuntimeType.RUBY, "x86_64", ArchitectureType.x86_64),
       mockLambdaFunction("Ruby34Function", "ruby3.4", RuntimeType.RUBY, "x86_64", ArchitectureType.x86_64),
+      mockLambdaFunction("Ruby40Function", "ruby4.0", RuntimeType.RUBY, "x86_64", ArchitectureType.x86_64),
       mockLambdaFunction("GoFunction", "go1.10", RuntimeType.UNSUPPORTED, "x86_64", ArchitectureType.x86_64),
       mockLambdaFunction("RefFunction", "nodejs14.x", RuntimeType.NODE, "arm64", ArchitectureType.ARM64, {
         Ref: "ValueRef",


### PR DESCRIPTION
### What does this PR do?
Add support for the ruby 4 layer

### Motivation
The Datadog layer for Ruby 4 was just released, we should support adding it across our tools.

### Testing Guidelines
Added to unit tests


### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
