### PR TITLE
chore: add Datadog Code Coverage upload, remove CodeCov

### DIFF
--- a/.github/workflows/build_serverless.yml
+++ b/.github/workflows/build_serverless.yml
@@ -120,4 +120,5 @@ jobs:
         if: matrix.node-version == 24
         env:
           DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
-        run: npx --yes @datadog/datadog-ci coverage upload --service datadog-cloudformation-macro coverage/lcov.info
+          DD_SERVICE: datadog-cloudformation-macro
+        run: npx --yes @datadog/datadog-ci coverage upload coverage/lcov.info

--- a/.github/workflows/build_serverless.yml
+++ b/.github/workflows/build_serverless.yml
@@ -116,5 +116,8 @@ jobs:
       - name: Run tests
         run: yarn test
 
-      - name: Upload code coverage report
-        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
+      - name: Upload coverage to Datadog
+        if: matrix.node-version == 24
+        env:
+          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
+        run: npx --yes @datadog/datadog-ci coverage upload --service datadog-cloudformation-macro coverage/lcov.info

--- a/.github/workflows/build_serverless.yml
+++ b/.github/workflows/build_serverless.yml
@@ -118,6 +118,7 @@ jobs:
 
       - name: Upload coverage to Datadog
         if: matrix.node-version == 24
+        continue-on-error: true
         env:
           DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
           DD_SERVICE: datadog-cloudformation-macro


### PR DESCRIPTION
## Summary

- Replace `codecov/codecov-action` upload step with Datadog CI coverage upload using `@datadog/datadog-ci`
- Coverage is already collected by Jest (`collectCoverage: true`, `lcovonly` reporter in `serverless/package.json`)
- Upload only runs on Node 24 (matrix condition) to avoid duplicate uploads
- Removes dependency on Codecov; onboards to Datadog Code Coverage

## Test plan

- [ ] Verify CI passes on this PR
- [ ] After merge, confirm coverage appears in Datadog Code Coverage for service `datadog-cloudformation-macro`
- [ ] Add `DATADOG_API_KEY` secret to repository settings if not already present

🤖 Generated with [Claude Code](https://claude.com/claude-code)