### PR TITLE
chore: add e2e cfn templates

### DIFF
--- a/serverless/e2e/templates/macro.yml
+++ b/serverless/e2e/templates/macro.yml
@@ -58,7 +58,7 @@ Resources:
       Description: Datadog Serverless macro (e2e) -- instruments Lambda functions in a CloudFormation template.
       Handler: src/index.handler
       Runtime: nodejs24.x
-      Timeout: 30
+      Timeout: 10
       Role: !GetAtt MacroExecutionRole.Arn
       Code:
         S3Bucket: !Ref SourceBucket

--- a/serverless/e2e/templates/macro.yml
+++ b/serverless/e2e/templates/macro.yml
@@ -1,0 +1,86 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  Registers the Datadog Serverless CloudFormation macro for e2e testing. Mirrors
+  the shipped serverless/template.yml (same macro Lambda code, built from source),
+  but parameterizes the macro registration Name -- which is account+region global --
+  so multiple e2e runs can register the macro in the same region concurrently.
+
+Parameters:
+  MacroName:
+    Type: String
+    Description: Unique registration name for the AWS::CloudFormation::Macro resource.
+  FunctionName:
+    Type: String
+    Description: Name of the macro Lambda function.
+  SourceBucket:
+    Type: String
+    Description: S3 bucket holding the macro zip built from source.
+  SourceKey:
+    Type: String
+    Description: S3 key of the macro zip built from source.
+  CreatedTs:
+    Type: String
+    Description: Unix timestamp freshness tag (one_e2e_created) set at creation.
+
+Resources:
+  MacroExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: macro-logs
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                  - logs:CreateLogGroup
+                  - logs:DescribeLogGroups
+                  - logs:DescribeSubscriptionFilters
+                  - logs:PutSubscriptionFilter
+                Resource: "*"
+      Tags:
+        - Key: one_e2e_created
+          Value: !Ref CreatedTs
+
+  MacroFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: !Ref FunctionName
+      Description: Datadog Serverless macro (e2e) -- instruments Lambda functions in a CloudFormation template.
+      Handler: src/index.handler
+      Runtime: nodejs24.x
+      Timeout: 30
+      Role: !GetAtt MacroExecutionRole.Arn
+      Code:
+        S3Bucket: !Ref SourceBucket
+        S3Key: !Ref SourceKey
+      Tags:
+        - Key: one_e2e_created
+          Value: !Ref CreatedTs
+
+  MacroLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/lambda/${MacroFunction}
+      RetentionInDays: 1
+
+  Macro:
+    Type: AWS::CloudFormation::Macro
+    Properties:
+      Name: !Ref MacroName
+      FunctionName: !GetAtt MacroFunction.Arn
+
+Outputs:
+  MacroName:
+    Value: !Ref MacroName
+  MacroFunctionArn:
+    Value: !GetAtt MacroFunction.Arn

--- a/serverless/e2e/templates/macro.yml
+++ b/serverless/e2e/templates/macro.yml
@@ -72,6 +72,9 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${MacroFunction}
       RetentionInDays: 1
+      Tags:
+        - Key: one_e2e_created
+          Value: !Ref CreatedTs
 
   Macro:
     Type: AWS::CloudFormation::Macro

--- a/serverless/e2e/templates/workload-instrumented.yml
+++ b/serverless/e2e/templates/workload-instrumented.yml
@@ -1,0 +1,86 @@
+AWSTemplateFormatVersion: "2010-09-09"
+# The macro registration name is account+region global and unique per run, so it
+# cannot be a CloudFormation parameter (the Transform name must be a literal).
+# The e2e runner substitutes __MACRO_NAME__ before deploying. Everything else is
+# passed as stack parameters and referenced here, keeping the API key out of the
+# template file.
+Transform:
+  - AWS::Serverless-2016-10-31
+  - Name: __MACRO_NAME__
+    Parameters:
+      apiKey: !Ref DDApiKey
+      site: !Ref DDSite
+      nodeLayerVersion: !Ref NodeLayerVersion
+      extensionLayerVersion: !Ref ExtensionLayerVersion
+      service: !Ref DDService
+      env: !Ref DDEnv
+      version: !Ref DDVersion
+      tags: !Ref DDTags
+Description: >
+  Instrumented e2e workload: the same minimal Node.js Lambda, with the Datadog
+  Serverless macro applied via the Transform above. Deploying this template is the
+  APPLY step -- CloudFormation invokes the macro, which adds the Datadog Node.js +
+  Extension layers, DD_* env vars, the handler redirect, and the dd_sls_macro tag.
+
+Parameters:
+  FunctionName:
+    Type: String
+    Description: Ephemeral function name (one-e2e-cfnmacro-lambda-<runid>).
+  RunId:
+    Type: String
+    Description: Unique run id, logged by the handler and used to correlate telemetry.
+  CreatedTs:
+    Type: String
+    Description: Unix timestamp freshness tag (one_e2e_created) set at creation.
+  DDApiKey:
+    Type: String
+    NoEcho: true
+    Description: Datadog API key wired into the extension to ship telemetry.
+  DDSite:
+    Type: String
+    Description: Datadog site the extension ships telemetry to.
+  DDService:
+    Type: String
+    Description: DD_SERVICE -- identifying tag on ingested telemetry.
+  DDEnv:
+    Type: String
+    Description: DD_ENV -- identifying tag on ingested telemetry.
+  DDVersion:
+    Type: String
+    Description: DD_VERSION -- identifying tag on ingested telemetry.
+  DDTags:
+    Type: String
+    Description: DD_TAGS (comma-separated key:value), carries the run-id marker.
+  NodeLayerVersion:
+    Type: Number
+    Description: Pinned Datadog Node.js layer version.
+  ExtensionLayerVersion:
+    Type: Number
+    Description: Pinned Datadog Lambda Extension layer version.
+
+Resources:
+  HelloWorldFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Ref FunctionName
+      Handler: index.handler
+      Runtime: nodejs22.x
+      Architectures:
+        - x86_64
+      Timeout: 30
+      MemorySize: 256
+      InlineCode: |
+        exports.handler = async () => {
+          const runId = process.env.E2E_RUN_ID;
+          console.log(JSON.stringify({ message: "one-e2e hello world", one_e2e_run_id: runId }));
+          return { statusCode: 200, body: "hello, world" };
+        };
+      Environment:
+        Variables:
+          E2E_RUN_ID: !Ref RunId
+      Tags:
+        one_e2e_created: !Ref CreatedTs
+
+Outputs:
+  FunctionName:
+    Value: !Ref FunctionName

--- a/serverless/e2e/templates/workload-uninstrumented.yml
+++ b/serverless/e2e/templates/workload-uninstrumented.yml
@@ -1,0 +1,48 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: AWS::Serverless-2016-10-31
+Description: >
+  Uninstrumented e2e workload: a minimal Node.js Lambda that logs a line carrying
+  the run id and serves the invoke trigger. This is the provisioned baseline and
+  the post-REMOVE end state -- it contains no Datadog config. The handler mirrors
+  the trivial hello-world handler from serverless-self-monitoring; tracing/log
+  collection are auto-injected by the macro, so no tracer setup is needed here.
+
+Parameters:
+  FunctionName:
+    Type: String
+    Description: Ephemeral function name (one-e2e-cfnmacro-lambda-<runid>).
+  RunId:
+    Type: String
+    Description: Unique run id, logged by the handler and used to correlate telemetry.
+  CreatedTs:
+    Type: String
+    Description: Unix timestamp freshness tag (one_e2e_created) set at creation.
+
+Resources:
+  HelloWorldFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Ref FunctionName
+      Handler: index.handler
+      Runtime: nodejs22.x
+      Architectures:
+        - x86_64
+      Timeout: 30
+      MemorySize: 256
+      InlineCode: |
+        exports.handler = async () => {
+          const runId = process.env.E2E_RUN_ID;
+          // Emit a structured log line so the extension forwards it to Datadog logs,
+          // tagged with the run id for identity assertions.
+          console.log(JSON.stringify({ message: "one-e2e hello world", one_e2e_run_id: runId }));
+          return { statusCode: 200, body: "hello, world" };
+        };
+      Environment:
+        Variables:
+          E2E_RUN_ID: !Ref RunId
+      Tags:
+        one_e2e_created: !Ref CreatedTs
+
+Outputs:
+  FunctionName:
+    Value: !Ref FunctionName


### PR DESCRIPTION
## Stack (2 of 3)
Middle of a 3-PR stack splitting the new Lambda e2e suite by review concern:
1. #255 -- shared synced helpers
2. **(this) e2e CloudFormation templates**
3. #257 -- lifecycle test + macro assertions + CI workflow

### What does this PR do?

Adds the CloudFormation templates the e2e suite deploys. Infra only -- no test code (that lands in #257):

- `macro.yml` -- registers the Datadog Serverless macro under test. Mirrors the shipped `serverless/template.yml` (same macro Lambda, built from source) but parameterizes the macro registration `Name` -- which is account+region global -- so concurrent runs can register in the same region without colliding.
- `workload-uninstrumented.yml` -- a bare Lambda workload, the starting and clean end-state.
- `workload-instrumented.yml` -- the same workload redefined through the macro (`Transform`), with a `__MACRO_NAME__` placeholder the test swaps for the run-unique registration name.

### Motivation

These fixtures are the thing the lifecycle test drives apply/re-apply/remove against. Splitting them out keeps the test PR focused on assertions rather than YAML.

### Testing Guidelines

No behavior on its own -- deployed and asserted against by the suite in #257.

### Additional Notes

Run-unique naming and freshness tags (`one_e2e_created`) let the cross-repo sweeper reclaim leaked resources.

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
