### PR TITLE
chore: add e2e lifecycle test + workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,114 @@
+name: e2e
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'serverless/src/**'
+      - 'serverless/e2e/**'
+      - 'serverless/template.yml'
+      - 'serverless/package.json'
+      - 'serverless/yarn.lock'
+      - '.github/workflows/e2e.yml'
+  pull_request:
+    paths:
+      - 'serverless/src/**'
+      - 'serverless/e2e/**'
+      - 'serverless/template.yml'
+      - 'serverless/package.json'
+      - 'serverless/yarn.lock'
+      - '.github/workflows/e2e.yml'
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+# OIDC federation to AWS requires id-token write; no long-lived credentials.
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  # Path filter: only spend cloud resources when the macro, its template, or the
+  # suite itself changed. The e2e job always runs (so it reports a status check)
+  # but self-skips via SKIP_LAMBDA_TESTS when nothing relevant changed.
+  check-lambda-changes:
+    name: Check macro/e2e changes
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.filter.outputs.lambda }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
+        id: filter
+        with:
+          filters: |
+            lambda:
+              - 'serverless/src/**'
+              - 'serverless/template.yml'
+              - 'serverless/package.json'
+              - 'serverless/e2e/**'
+              - '.github/workflows/e2e.yml'
+
+  e2e-test:
+    name: AWS Lambda e2e
+    runs-on: ubuntu-latest
+    needs: [check-lambda-changes]
+    defaults:
+      run:
+        working-directory: serverless
+    env:
+      FORCE_COLOR: 1
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      # The workload runtime under test is pinned in the template (nodejs22.x); the
+      # test runner uses the repo's canonical Node version.
+      - name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+
+      - name: Cache Node modules
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Type-check e2e suite
+        run: yarn test:e2e:typecheck
+
+      # The live suite runs whenever relevant paths changed. The dd-sts / AWS OIDC
+      # steps must succeed in that case -- an auth/federation failure fails the job
+      # loudly rather than self-skipping green.
+      # Short-lived Datadog API + App keys via OIDC federation (dd-sts), governed by the
+      # policy in dd-source. No static Datadog keys are stored in this repo.
+      - name: Get Datadog credentials (dd-sts)
+        id: dd-sts
+        if: needs.check-lambda-changes.outputs.should_run == 'true'
+        uses: DataDog/dd-sts-action@2e8187910199bd93129520183c093e19aa585c75 # v1.0.0
+        with:
+          policy: datadog-cloudformation-macro-e2e
+
+      - name: AWS auth (OIDC)
+        if: needs.check-lambda-changes.outputs.should_run == 'true'
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN_E2E }}
+          aws-region: ${{ vars.AWS_REGION_E2E || 'ap-northeast-3' }}
+          role-session-name: e2e-cfnmacro-${{ github.run_id }}
+
+      - name: Run e2e tests
+        run: yarn test:e2e
+        env:
+          SKIP_LAMBDA_TESTS: ${{ needs.check-lambda-changes.outputs.should_run != 'true' }}
+          AWS_REGION: ${{ vars.AWS_REGION_E2E || 'ap-northeast-3' }}
+          # The extension ships telemetry with DD_API_KEY; the suite queries with both.
+          DD_API_KEY: ${{ steps.dd-sts.outputs.api_key }}
+          DD_APP_KEY: ${{ steps.dd-sts.outputs.app_key }}
+          DATADOG_API_KEY: ${{ steps.dd-sts.outputs.api_key }}
+          DATADOG_APP_KEY: ${{ steps.dd-sts.outputs.app_key }}
+          DD_SITE: ${{ vars.DD_SITE_E2E || 'datadoghq.com' }}

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ coverage/
 packaged.template
 dist/
 .macro
+# e2e local, non-secret overrides
+**/e2e/.env.local

--- a/serverless/e2e/.env.local.example
+++ b/serverless/e2e/.env.local.example
@@ -1,0 +1,15 @@
+# Copy to e2e/.env.local for local runs. This file is gitignored.
+# Secrets are read from the ambient environment; only put non-secret overrides here.
+
+# AWS region for ephemeral test resources (default sa-east-1).
+# AWS_REGION=sa-east-1
+
+# Datadog site the extension ships to and the API client queries (default datadoghq.com).
+# DD_SITE=datadoghq.com
+
+# Pinned artifact versions (override only to test against a newer layer/extension).
+# NODE_LAYER_VERSION=139
+# EXTENSION_LAYER_VERSION=97
+
+# Correlate a known run id (default: random per process).
+# E2E_RUN_ID=deadbeef

--- a/serverless/e2e/README.md
+++ b/serverless/e2e/README.md
@@ -1,0 +1,95 @@
+# CloudFormation macro — AWS Lambda e2e suite
+
+End-to-end test for the Datadog Serverless CloudFormation macro on AWS Lambda. It
+proves the macro's mechanism — applying the `DatadogServerless` transform to a
+CloudFormation stack — yields a correctly instrumented function with telemetry
+flowing into Datadog, and that removing the transform leaves a clean end-state.
+
+Conforms to the shared serverless instrumentation e2e contract
+(`serverless-ci/e2e/spec.md`); mirrors the `datadog-ci` reference suite
+(`e2e/cloud-run.test.ts` + `e2e/helpers/*`), with runner-agnostic helpers.
+
+## Lifecycle (`lambda.test.ts`)
+
+1. **Provision** — build the macro from source, register it as a CloudFormation
+   macro, and deploy an uninstrumented Node.js workload Lambda.
+2. **APPLY** — `aws cloudformation deploy` of the workload template *with* the
+   `DatadogServerless` transform; verify config (pinned Node + Extension layers,
+   `DD_*` env vars, handler redirect, `dd_sls_macro` tag).
+3. **TRIGGER** — `aws lambda invoke`; poll Datadog until spans *and* logs appear,
+   filtered by the run's identifying tags (`service`, `env`, `version`, run id).
+4. **RE-APPLY** — deploy again; assert idempotent (no diff, layers not duplicated).
+5. **REMOVE** — deploy the uninstrumented template; assert all Datadog config,
+   `DD_*` env vars, and the macro tag are gone.
+6. **Teardown** — always deletes both stacks and the macro source bucket.
+
+## What's pinned
+
+Artifact versions are pinned (`constants.ts`) so a failure blames the macro, not an
+upstream bump: Node layer (`NODE_LAYER_VERSION`), Extension layer
+(`EXTENSION_LAYER_VERSION`), one canonical runtime (`nodejs22.x`). Override via env
+when intentionally testing a newer artifact.
+
+## Resource hygiene
+
+Every resource is named `one-e2e-cfnmacro-lambda-<runid>` and tagged
+`one_e2e_created:<unix-ts>` at creation. The shared cross-repo sweeper deletes stale
+`one-e2e-` resources; in-test teardown is the fast path, the sweeper the backstop.
+
+## Running locally
+
+Prerequisites:
+
+- **AWS auth** with permission to deploy CloudFormation, Lambda, IAM, S3 in a
+  **non-production** account (the suite never touches the Datadog layer-publishing
+  account `464622532012`). Datadog engineers use:
+
+  ```bash
+  aws-vault exec sso-serverless-sandbox-account-admin -- yarn test:e2e
+  ```
+
+- **Datadog API + APP keys** for the org telemetry lands in (the extension uses the
+  API key to ship; the suite uses both to query). Mint these with `dd-auth` rather
+  than pasting raw keys -- it injects short-lived `$DD_API_KEY` and `$DD_APP_KEY`
+  into the wrapped subprocess.
+
+  `DD_SITE` defaults to `datadoghq.com`; override for other sites.
+
+Then:
+
+```bash
+cd serverless
+yarn install
+
+# Datadog auth: dd-auth mints short-lived keys for the org -- no pasted keys.
+aws-vault exec sso-serverless-sandbox-account-admin -- \
+  dd-auth --domain app.datadoghq.com -- bash -c '
+    export DATADOG_API_KEY="$DD_API_KEY" DATADOG_APP_KEY="$DD_APP_KEY"
+    yarn test:e2e
+  '
+```
+
+Optional non-secret overrides go in `e2e/.env.local` (see `.env.local.example`).
+
+A full run takes ~10–15 minutes (build + macro registration + workload lifecycle +
+telemetry polling). Type-check the suite without deploying anything via
+`yarn test:e2e:typecheck`.
+
+## CI
+
+Runs in GitHub Actions (`.github/workflows/e2e.yml`) behind a path
+filter, gated by `SKIP_LAMBDA_TESTS`, with AWS access via OIDC federation (no
+long-lived keys). Datadog credentials are minted at runtime via dd-sts.
+
+The live suite runs whenever relevant paths change; the dd-sts / AWS OIDC steps must then
+succeed -- an auth or federation failure fails the job loudly rather than skipping green.
+When nothing relevant changed it self-skips via `SKIP_LAMBDA_TESTS`. Required repo config:
+
+- `vars.AWS_ROLE_ARN_E2E` — OIDC role ARN (deploy perms for CloudFormation,
+  Lambda, IAM, S3 in a non-prod account; `lambda:InvokeFunction` on the macro fn).
+- Datadog auth (dd-sts): short-lived API + App keys via
+  [`DataDog/dd-sts-action`](https://github.com/DataDog/dd-sts-action) under the
+  `datadog-cloudformation-macro-e2e` policy — no static Datadog keys in this repo.
+- Optional: `vars.AWS_REGION_E2E` (default `ap-northeast-3`), `vars.DD_SITE_E2E`.
+
+The type-check step always runs, so the suite is compile-checked on every PR.

--- a/serverless/e2e/helpers/aws.ts
+++ b/serverless/e2e/helpers/aws.ts
@@ -1,0 +1,123 @@
+import { execPromise, execPromiseWithRetries, ExecResult } from "./exec";
+import { CREATED_TS, execSync, FRESHNESS_TAG_KEY } from "./e2e.config";
+
+// Thin, runner-agnostic wrappers over the `aws` CLI. The CLI inherits AWS creds
+// from the environment (locally via `aws-vault exec ... --`, in CI via OIDC), so
+// no SDK auth wiring is needed here.
+
+const shellQuote = (value: string): string => `'${value.replace(/'/g, "'\\''")}'`;
+
+export interface DeployArgs {
+  stackName: string;
+  templateFile: string;
+  region: string;
+  parameters?: Record<string, string>;
+  // Extra resource tags applied to every stack resource that supports tagging.
+  tags?: Record<string, string>;
+  capabilities?: string[];
+}
+
+const buildDeployCommand = (args: DeployArgs): string => {
+  const capabilities = args.capabilities ?? ["CAPABILITY_AUTO_EXPAND", "CAPABILITY_IAM", "CAPABILITY_NAMED_IAM"];
+  const tags = { [FRESHNESS_TAG_KEY]: String(CREATED_TS), ...args.tags };
+
+  const parts = [
+    "aws cloudformation deploy",
+    `--stack-name ${args.stackName}`,
+    `--template-file ${shellQuote(args.templateFile)}`,
+    `--region ${args.region}`,
+    `--capabilities ${capabilities.join(" ")}`,
+  ];
+
+  const params = Object.entries(args.parameters ?? {});
+  if (params.length > 0) {
+    parts.push(`--parameter-overrides ${params.map(([k, v]) => `${k}=${shellQuote(v)}`).join(" ")}`);
+  }
+
+  const tagPairs = Object.entries(tags);
+  if (tagPairs.length > 0) {
+    parts.push(`--tags ${tagPairs.map(([k, v]) => `${k}=${shellQuote(v)}`).join(" ")}`);
+  }
+
+  return parts.join(" ");
+};
+
+// Result of an APPLY/re-APPLY deploy. `noChanges` distinguishes the idempotent
+// no-op (CloudFormation reports an empty changeset) from a real deploy.
+export interface DeployResult extends ExecResult {
+  noChanges: boolean;
+}
+
+export const cfnDeploy = async (args: DeployArgs): Promise<DeployResult> => {
+  const result = await execPromiseWithRetries(buildDeployCommand(args));
+  const output = `${result.stdout}\n${result.stderr}`;
+  // `aws cloudformation deploy` signals an empty changeset either via a zero exit
+  // (CLI v2) or a non-zero exit with this message (older CLI). Treat both as "no diff".
+  const noChanges = /No changes to deploy/i.test(output);
+  if (result.exitCode !== 0 && !noChanges) {
+    throw new Error(`Deploy of ${args.stackName} failed (exit ${result.exitCode}):\n${output}`);
+  }
+  return { ...result, noChanges };
+};
+
+export const cfnDeleteAndWait = async (stackName: string, region: string): Promise<void> => {
+  await execPromise(`aws cloudformation delete-stack --stack-name ${stackName} --region ${region}`);
+  // Best-effort wait; teardown must not throw and block sibling cleanup.
+  await execPromise(`aws cloudformation wait stack-delete-complete --stack-name ${stackName} --region ${region}`);
+};
+
+export interface LambdaConfiguration {
+  Handler: string;
+  Runtime: string;
+  Layers?: { Arn: string }[];
+  Environment?: { Variables?: Record<string, string> };
+  FunctionArn: string;
+}
+
+export const getFunctionConfiguration = (functionName: string, region: string): LambdaConfiguration => {
+  const out = execSync(
+    `aws lambda get-function-configuration --function-name ${functionName} --region ${region} --output json`,
+  );
+  return JSON.parse(out) as LambdaConfiguration;
+};
+
+export const getFunctionTags = (functionArn: string, region: string): Record<string, string> => {
+  const out = execSync(`aws lambda list-tags --resource ${functionArn} --region ${region} --output json`);
+  return (JSON.parse(out).Tags ?? {}) as Record<string, string>;
+};
+
+export const invokeFunction = async (functionName: string, region: string): Promise<ExecResult> => {
+  // Output payload to a temp file we don't read; we only care that the invoke
+  // succeeds and produces telemetry.
+  return execPromiseWithRetries(
+    `aws lambda invoke --function-name ${functionName} --region ${region} --payload '{}' --cli-binary-format raw-in-base64-out /tmp/${functionName}-invoke.json`,
+  );
+};
+
+// --- S3 source bucket for the macro zip --------------------------------------
+
+export const createSourceBucket = async (bucket: string, region: string): Promise<void> => {
+  // us-east-1 rejects an explicit LocationConstraint; every other region requires it.
+  const locationFlag = region === "us-east-1" ? "" : `--create-bucket-configuration LocationConstraint=${region}`;
+  const result = await execPromiseWithRetries(
+    `aws s3api create-bucket --bucket ${bucket} --region ${region} ${locationFlag}`,
+  );
+  if (result.exitCode !== 0 && !/BucketAlreadyOwnedByYou/.test(`${result.stdout}${result.stderr}`)) {
+    throw new Error(`Failed to create source bucket ${bucket}: ${result.stderr}`);
+  }
+  await execPromise(
+    `aws s3api put-bucket-tagging --bucket ${bucket} --region ${region} --tagging 'TagSet=[{Key=${FRESHNESS_TAG_KEY},Value=${CREATED_TS}}]'`,
+  );
+};
+
+export const uploadFile = async (localPath: string, bucket: string, key: string, region: string): Promise<void> => {
+  const result = await execPromiseWithRetries(`aws s3 cp ${shellQuote(localPath)} s3://${bucket}/${key} --region ${region}`);
+  if (result.exitCode !== 0) {
+    throw new Error(`Failed to upload ${localPath} to s3://${bucket}/${key}: ${result.stderr}`);
+  }
+};
+
+export const emptyAndDeleteBucket = async (bucket: string, region: string): Promise<void> => {
+  await execPromise(`aws s3 rm s3://${bucket} --recursive --region ${region}`);
+  await execPromise(`aws s3api delete-bucket --bucket ${bucket} --region ${region}`);
+};

--- a/serverless/e2e/helpers/aws.ts
+++ b/serverless/e2e/helpers/aws.ts
@@ -7,6 +7,13 @@ import { CREATED_TS, FRESHNESS_TAG_KEY } from "./e2e.config";
 
 const shellQuote = (value: string): string => `'${value.replace(/'/g, "'\\''")}'`;
 
+// Transient AWS throttling errors safe to retry on a bounded budget.
+const AWS_RETRY = {
+  retryPatterns: ["Throttling", "Rate exceeded", "RequestThrottled"],
+  maxAttempts: 3,
+  delaySeconds: 15,
+};
+
 export interface DeployArgs {
   stackName: string;
   templateFile: string;
@@ -49,7 +56,7 @@ export interface DeployResult extends ExecResult {
 }
 
 export const cfnDeploy = async (args: DeployArgs): Promise<DeployResult> => {
-  const result = await execPromiseWithRetries(buildDeployCommand(args));
+  const result = await execPromiseWithRetries(buildDeployCommand(args), AWS_RETRY);
   const output = `${result.stdout}\n${result.stderr}`;
   // `aws cloudformation deploy` signals an empty changeset either via a zero exit
   // (CLI v2) or a non-zero exit with this message (older CLI). Treat both as "no diff".
@@ -71,6 +78,7 @@ export const invokeFunction = async (functionName: string, region: string): Prom
   // succeeds and produces telemetry.
   return execPromiseWithRetries(
     `aws lambda invoke --function-name ${functionName} --region ${region} --payload '{}' --cli-binary-format raw-in-base64-out /tmp/${functionName}-invoke.json`,
+    AWS_RETRY,
   );
 };
 
@@ -81,6 +89,7 @@ export const createSourceBucket = async (bucket: string, region: string): Promis
   const locationFlag = region === "us-east-1" ? "" : `--create-bucket-configuration LocationConstraint=${region}`;
   const result = await execPromiseWithRetries(
     `aws s3api create-bucket --bucket ${bucket} --region ${region} ${locationFlag}`,
+    AWS_RETRY,
   );
   if (result.exitCode !== 0 && !/BucketAlreadyOwnedByYou/.test(`${result.stdout}${result.stderr}`)) {
     throw new Error(`Failed to create source bucket ${bucket}: ${result.stderr}`);
@@ -91,7 +100,10 @@ export const createSourceBucket = async (bucket: string, region: string): Promis
 };
 
 export const uploadFile = async (localPath: string, bucket: string, key: string, region: string): Promise<void> => {
-  const result = await execPromiseWithRetries(`aws s3 cp ${shellQuote(localPath)} s3://${bucket}/${key} --region ${region}`);
+  const result = await execPromiseWithRetries(
+    `aws s3 cp ${shellQuote(localPath)} s3://${bucket}/${key} --region ${region}`,
+    AWS_RETRY,
+  );
   if (result.exitCode !== 0) {
     throw new Error(`Failed to upload ${localPath} to s3://${bucket}/${key}: ${result.stderr}`);
   }

--- a/serverless/e2e/helpers/aws.ts
+++ b/serverless/e2e/helpers/aws.ts
@@ -1,5 +1,5 @@
 import { execPromise, execPromiseWithRetries, ExecResult } from "./exec";
-import { CREATED_TS, execSync, FRESHNESS_TAG_KEY } from "./e2e.config";
+import { CREATED_TS, FRESHNESS_TAG_KEY } from "./e2e.config";
 
 // Thin, runner-agnostic wrappers over the `aws` CLI. The CLI inherits AWS creds
 // from the environment (locally via `aws-vault exec ... --`, in CI via OIDC), so
@@ -64,26 +64,6 @@ export const cfnDeleteAndWait = async (stackName: string, region: string): Promi
   await execPromise(`aws cloudformation delete-stack --stack-name ${stackName} --region ${region}`);
   // Best-effort wait; teardown must not throw and block sibling cleanup.
   await execPromise(`aws cloudformation wait stack-delete-complete --stack-name ${stackName} --region ${region}`);
-};
-
-export interface LambdaConfiguration {
-  Handler: string;
-  Runtime: string;
-  Layers?: { Arn: string }[];
-  Environment?: { Variables?: Record<string, string> };
-  FunctionArn: string;
-}
-
-export const getFunctionConfiguration = (functionName: string, region: string): LambdaConfiguration => {
-  const out = execSync(
-    `aws lambda get-function-configuration --function-name ${functionName} --region ${region} --output json`,
-  );
-  return JSON.parse(out) as LambdaConfiguration;
-};
-
-export const getFunctionTags = (functionArn: string, region: string): Record<string, string> => {
-  const out = execSync(`aws lambda list-tags --resource ${functionArn} --region ${region} --output json`);
-  return (JSON.parse(out).Tags ?? {}) as Record<string, string>;
 };
 
 export const invokeFunction = async (functionName: string, region: string): Promise<ExecResult> => {

--- a/serverless/e2e/helpers/e2e.config.ts
+++ b/serverless/e2e/helpers/e2e.config.ts
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict";
+import child_process from "node:child_process";
+import crypto from "node:crypto";
+
+import { execPromise } from "./exec";
+import { type E2ENaming } from "./naming";
+import { FRESHNESS_TAG_KEY, RUN_ID_TAG_KEY } from "./naming";
+import { type ExpectedLayers, type LambdaVerifierConfig } from "./lambda-verifier";
+
+// Repo-local config feeding the shared, parameterized e2e helpers. This file is NOT
+// synced -- it holds everything specific to datadog-cloudformation-macro: resource
+// naming, pinned artifact versions, the CFN deploy buffer, and the LambdaVerifierConfig
+// the shared verifier reads through its arguments. The shared files (exec/naming/
+// lambda-verifier/lambda-telemetry-checker) import nothing from here.
+
+export const NAMING: E2ENaming = { tool: "cfnmacro", platform: "lambda" };
+
+// --- Run identity + resource naming ------------------------------------------
+//
+// Resources are named `one-e2e-cfnmacro-lambda-<runid>` and tagged
+// `one_e2e_created:<unix-ts>` at creation so the cross-repo sweeper can identify
+// ownership + staleness. Stable per-process run id; override via E2E_RUN_ID.
+
+export const RUN_ID = process.env.E2E_RUN_ID ?? crypto.randomBytes(4).toString("hex");
+
+// `one-e2e-cfnmacro-lambda-<runid>` -- 24 + 8 = 32 chars, within the 64-char Lambda
+// function-name and CloudFormation stack-name limits.
+export const RESOURCE_PREFIX = `one-e2e-${NAMING.tool}-${NAMING.platform}-${RUN_ID}`;
+
+export const FUNCTION_NAME = RESOURCE_PREFIX;
+export const WORKLOAD_STACK_NAME = RESOURCE_PREFIX;
+export const MACRO_STACK_NAME = `${RESOURCE_PREFIX}-macro`;
+
+// S3 bucket holding the freshly-built macro zip. Bucket names are global, lowercase,
+// hyphen-allowed; the run id keeps it unique.
+export const SOURCE_BUCKET = `${RESOURCE_PREFIX}-src`;
+
+// CloudFormation macro registration name is account+region global, so it must be unique
+// per run for parallel CI. Macro names are alphanumeric, so derive it from the (hex) run
+// id rather than the hyphenated prefix.
+export const MACRO_NAME = `DatadogServerlessE2e${RUN_ID}`;
+
+// Freshness tag -- native creation time isn't usable cross-cloud, so we stamp it.
+export const CREATED_TS = Math.floor(Date.now() / 1000);
+
+// Re-export the shared tag keys so repo-local helpers have a single config import.
+export { FRESHNESS_TAG_KEY, RUN_ID_TAG_KEY };
+
+// `key=value,...` form for `aws ... --tags` (CloudFormation, Lambda).
+export const freshnessTagCli = (): string => `${FRESHNESS_TAG_KEY}=${CREATED_TS}`;
+
+// --- exec: synchronous helper (not in the shared async exec API) -------------
+//
+// The shared exec.ts is async-only and runner-agnostic. The repo-local aws/macro-stack
+// helpers need a synchronous shell-out (config getters, the macro build), so keep that
+// here. CFN_MAX_BUFFER (16 MB) matches the shared default's lower bound and is large
+// enough for `aws cloudformation` / `get-function-configuration` JSON.
+export const CFN_MAX_BUFFER = 16 * 1024 * 1024;
+
+export const execSync = (command: string, env?: Record<string, string | undefined>): string =>
+  child_process.execSync(command, {
+    encoding: "utf-8",
+    env: { ...process.env, ...env },
+    maxBuffer: CFN_MAX_BUFFER,
+  });
+
+// --- Pinned artifact versions + deployment constants -------------------------
+//
+// Artifact versions (layer/extension) are PINNED so a failure blames the macro (the tool
+// under test), not an upstream layer/extension bump. Override via env to test newer.
+
+export const NODE_LAYER_VERSION = Number(process.env.NODE_LAYER_VERSION ?? "139");
+export const EXTENSION_LAYER_VERSION = Number(process.env.EXTENSION_LAYER_VERSION ?? "97");
+
+// One canonical runtime per platform (spec rule). Exhaustiveness lives upstream.
+export const LAMBDA_RUNTIME = "nodejs22.x";
+const NODE_LAYER_NAME = "Datadog-Node22-x"; // matches LAMBDA_RUNTIME nodejs22.x
+const EXTENSION_LAYER_NAME = "Datadog-Extension";
+
+// AWS account that publishes the public Datadog layers in commercial regions.
+const DD_LAYER_ACCOUNT_ID = "464622532012";
+
+// Region to deploy ephemeral test resources into. ap-northeast-3 is a less-used
+// region, which avoids account limits and contention with other workloads.
+export const AWS_REGION = process.env.AWS_REGION ?? "ap-northeast-3";
+
+// Datadog site the extension ships telemetry to and the API client queries.
+export const DD_SITE = process.env.DD_SITE ?? "datadoghq.com";
+
+// Fixed identifying tags applied via the macro and asserted on ingested telemetry.
+export const ENV_NAME = "one-e2e";
+// Version carried on telemetry; the run id makes it unique per run for identity asserts.
+export const ENV_VERSION = RUN_ID;
+
+// The macro names the function exactly as we asked (explicit FunctionName param), so the
+// run-unique service name *is* the deployed function name.
+export const functionName = (serviceName: string): string => serviceName;
+
+// Layer ARNs are derived from the pinned versions + the public Datadog layer account, so
+// a mismatch blames the macro/registry, not upstream drift.
+const layerArn = (region: string, name: string, version: number): string =>
+  `arn:aws:lambda:${region}:${DD_LAYER_ACCOUNT_ID}:layer:${name}:${version}`;
+
+const expectedLayerArns = (region: string): ExpectedLayers => {
+  assert.ok(region, "region is required to resolve expected layer ARNs");
+
+  return {
+    node: layerArn(region, NODE_LAYER_NAME, NODE_LAYER_VERSION),
+    extension: layerArn(region, EXTENSION_LAYER_NAME, EXTENSION_LAYER_VERSION),
+  };
+};
+
+export const VERIFIER: LambdaVerifierConfig = {
+  functionName,
+  expectedLayerArns,
+  redirectHandler: "/opt/nodejs/node_modules/datadog-lambda-js/handler.handler",
+  originalHandler: "index.handler",
+  // The macro tags every instrumented function with its own version marker.
+  toolTag: { key: "dd_sls_macro", pattern: /^v\d+\.\d+\.\d+/ },
+  env: {
+    apiKeyVars: ["DD_API_KEY", "DD_API_KEY_SECRET_ARN", "DD_KMS_API_KEY", "DD_API_KEY_SSM_ARN"],
+    present: ["DD_SITE"],
+    values: (serviceName) => ({
+      DD_TRACE_ENABLED: "true",
+      DD_SERVERLESS_LOGS_ENABLED: "true",
+      DD_SERVICE: serviceName,
+      DD_ENV: ENV_NAME,
+      DD_VERSION: ENV_VERSION,
+    }),
+  },
+};

--- a/serverless/e2e/helpers/macro-stack.ts
+++ b/serverless/e2e/helpers/macro-stack.ts
@@ -1,0 +1,49 @@
+import { cfnDeleteAndWait, cfnDeploy, createSourceBucket, emptyAndDeleteBucket, uploadFile } from "./aws";
+import { CREATED_TS, execSync, MACRO_NAME, MACRO_STACK_NAME, RESOURCE_PREFIX, RUN_ID, SOURCE_BUCKET } from "./e2e.config";
+
+// Builds the macro from source (the PR's code -- the tool under test) and registers
+// it as a CloudFormation macro in the test region. This is the artifact we pin the
+// suite against: a failure points at the macro, not at a published release.
+
+const MACRO_TEMPLATE = "e2e/templates/macro.yml";
+const MACRO_FUNCTION_NAME = `${RESOURCE_PREFIX}-macro-fn`;
+const ZIP_KEY = `macro/${RUN_ID}/serverless-macro-${RUN_ID}.zip`;
+
+export const deployMacroStack = async (region: string): Promise<void> => {
+  // Build dist/ (tsc + prod deps) and zip it, exactly as the release pipeline does.
+  console.log("Building macro zip from source...");
+  execSync(`bash tools/build_zip.sh ${RUN_ID}`);
+  const zipPath = `.macro/serverless-macro-${RUN_ID}.zip`;
+
+  console.log(`Uploading macro zip to s3://${SOURCE_BUCKET}/${ZIP_KEY}`);
+  await createSourceBucket(SOURCE_BUCKET, region);
+  await uploadFile(zipPath, SOURCE_BUCKET, ZIP_KEY, region);
+
+  console.log(`Registering macro "${MACRO_NAME}" via stack ${MACRO_STACK_NAME}`);
+  await cfnDeploy({
+    stackName: MACRO_STACK_NAME,
+    templateFile: MACRO_TEMPLATE,
+    region,
+    parameters: {
+      MacroName: MACRO_NAME,
+      FunctionName: MACRO_FUNCTION_NAME,
+      SourceBucket: SOURCE_BUCKET,
+      SourceKey: ZIP_KEY,
+      CreatedTs: String(CREATED_TS),
+    },
+    capabilities: ["CAPABILITY_IAM", "CAPABILITY_NAMED_IAM"],
+  });
+};
+
+export const teardownMacroStack = async (region: string): Promise<void> => {
+  try {
+    await cfnDeleteAndWait(MACRO_STACK_NAME, region);
+  } catch (error) {
+    console.error(`Failed to delete macro stack ${MACRO_STACK_NAME}:`, error);
+  }
+  try {
+    await emptyAndDeleteBucket(SOURCE_BUCKET, region);
+  } catch (error) {
+    console.error(`Failed to delete source bucket ${SOURCE_BUCKET}:`, error);
+  }
+};

--- a/serverless/e2e/lambda.test.ts
+++ b/serverless/e2e/lambda.test.ts
@@ -1,0 +1,132 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { cfnDeleteAndWait, cfnDeploy, invokeFunction } from "./helpers/aws";
+import {
+  AWS_REGION,
+  CREATED_TS,
+  ENV_NAME,
+  ENV_VERSION,
+  EXTENSION_LAYER_VERSION,
+  functionName,
+  FUNCTION_NAME,
+  LAMBDA_RUNTIME,
+  MACRO_NAME,
+  NODE_LAYER_VERSION,
+  RUN_ID,
+  RUN_ID_TAG_KEY,
+  VERIFIER,
+  WORKLOAD_STACK_NAME,
+} from "./helpers/e2e.config";
+import { checkTelemetryFlowing } from "./helpers/lambda-telemetry-checker";
+import { functionSnapshot, verifyInstrumented, verifyUninstrumented, type FunctionSnapshot } from "./helpers/lambda-verifier";
+import { deployMacroStack, teardownMacroStack } from "./helpers/macro-stack";
+
+const describeOrSkip = process.env.SKIP_LAMBDA_TESTS === "true" ? describe.skip : describe;
+
+const UNINSTRUMENTED_TEMPLATE = "e2e/templates/workload-uninstrumented.yml";
+
+// Telemetry identity carried through the whole run.
+const SERVICE = FUNCTION_NAME;
+
+// Prepare the instrumented template: the macro registration name is run-unique and
+// can't be a CloudFormation parameter, so substitute the literal before deploying.
+const prepareInstrumentedTemplate = (): string => {
+  const base = readFileSync("e2e/templates/workload-instrumented.yml", "utf-8");
+  const out = join(tmpdir(), `workload-instrumented-${RUN_ID}.yml`);
+  // `__MACRO_NAME__` is the literal placeholder token in the template, swapped for the run-unique name.
+  writeFileSync(out, base.replaceAll("__MACRO_NAME__", MACRO_NAME));
+  return out;
+};
+
+const baseParams = {
+  FunctionName: FUNCTION_NAME,
+  RunId: RUN_ID,
+  CreatedTs: String(CREATED_TS),
+};
+
+const instrumentedParams = {
+  ...baseParams,
+  DDApiKey: process.env.DD_API_KEY ?? process.env.DATADOG_API_KEY ?? "",
+  DDSite: process.env.DD_SITE ?? "datadoghq.com",
+  DDService: SERVICE,
+  DDEnv: ENV_NAME,
+  DDVersion: ENV_VERSION,
+  DDTags: `${RUN_ID_TAG_KEY}:${RUN_ID}`,
+  NodeLayerVersion: String(NODE_LAYER_VERSION),
+  ExtensionLayerVersion: String(EXTENSION_LAYER_VERSION),
+};
+
+const MINUTE = 60_000;
+
+describeOrSkip(`cfn-macro lambda e2e (${LAMBDA_RUNTIME})`, () => {
+  let instrumentedTemplate: string;
+  let firstSnapshot: FunctionSnapshot;
+
+  beforeAll(async () => {
+    instrumentedTemplate = prepareInstrumentedTemplate();
+    // Build + register the macro (the tool under test) from source.
+    await deployMacroStack(AWS_REGION);
+    // Provision the uninstrumented workload (ephemeral, uniquely named).
+    await cfnDeploy({
+      stackName: WORKLOAD_STACK_NAME,
+      templateFile: UNINSTRUMENTED_TEMPLATE,
+      region: AWS_REGION,
+      parameters: baseParams,
+    });
+  }, 15 * MINUTE);
+
+  afterAll(async () => {
+    // Teardown always runs, even on failure. The cross-repo sweeper is the backstop
+    // for cancelled CI where this never runs.
+    try {
+      await cfnDeleteAndWait(WORKLOAD_STACK_NAME, AWS_REGION);
+    } catch (error) {
+      console.error(`Failed to delete workload stack ${WORKLOAD_STACK_NAME}:`, error);
+    }
+    await teardownMacroStack(AWS_REGION);
+  }, 15 * MINUTE);
+
+  it("APPLY: instruments the function (config present)", async () => {
+    await cfnDeploy({
+      stackName: WORKLOAD_STACK_NAME,
+      templateFile: instrumentedTemplate,
+      region: AWS_REGION,
+      parameters: instrumentedParams,
+    });
+    await verifyInstrumented(VERIFIER, SERVICE, AWS_REGION);
+    firstSnapshot = await functionSnapshot(VERIFIER, SERVICE, AWS_REGION);
+  }, 10 * MINUTE);
+
+  it("TRIGGER: telemetry (traces + logs) flows with identifying tags", async () => {
+    const invoke = await invokeFunction(FUNCTION_NAME, AWS_REGION);
+    expect(invoke.exitCode).toBe(0);
+    await checkTelemetryFlowing({ serviceName: SERVICE, env: ENV_NAME, version: ENV_VERSION, runId: RUN_ID });
+  }, 10 * MINUTE);
+
+  it("RE-APPLY: is idempotent (no diff, no duplicate)", async () => {
+    const result = await cfnDeploy({
+      stackName: WORKLOAD_STACK_NAME,
+      templateFile: instrumentedTemplate,
+      region: AWS_REGION,
+      parameters: instrumentedParams,
+    });
+    // Still instrumented, and byte-for-byte the same instrumentation as the first apply
+    // -- the macro must not stack a second copy of each layer or otherwise drift.
+    await verifyInstrumented(VERIFIER, SERVICE, AWS_REGION);
+    const secondSnapshot = await functionSnapshot(VERIFIER, SERVICE, AWS_REGION);
+    expect(secondSnapshot).toEqual(firstSnapshot);
+    console.log(`Re-apply reported noChanges=${result.noChanges}`);
+  }, 10 * MINUTE);
+
+  it("REMOVE: reverts to a clean end-state (no residue)", async () => {
+    // The CFN-macro remove driver is `delete-stack` (per spec): tearing down the
+    // workload stack removes the function and all its DD config. The clean end-state
+    // is the function (and its instrumentation) being gone.
+    await cfnDeleteAndWait(WORKLOAD_STACK_NAME, AWS_REGION);
+    await verifyUninstrumented(VERIFIER, SERVICE, AWS_REGION);
+  }, 10 * MINUTE);
+});

--- a/serverless/e2e/tsconfig.json
+++ b/serverless/e2e/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2021"],
+    "strict": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["."]
+}

--- a/serverless/package.json
+++ b/serverless/package.json
@@ -10,12 +10,15 @@
     "build": "tsc && cp package.json dist/package.json && npm install --omit=dev --prefix dist",
     "test": "jest",
     "test:watch": "jest --watch",
+    "test:e2e": "vitest run --config vitest.config.e2e.ts",
+    "test:e2e:typecheck": "tsc --noEmit -p e2e/tsconfig.json",
     "coverage": "jest --coverage",
     "lint": "eslint -c .eslintrc . --ext .ts",
     "check-formatting": "prettier --check src/** test/**",
     "format": "prettier --write src/** test/**"
   },
   "devDependencies": {
+    "@datadog/datadog-api-client": "1.39.0",
     "@types/jest": "30.0.0",
     "@types/node": "25.5.2",
     "@typescript-eslint/eslint-plugin": "6.21.0",
@@ -24,7 +27,8 @@
     "jest": "30.3.0",
     "prettier": "3.8.1",
     "ts-jest": "29.4.9",
-    "typescript": "5.9.3"
+    "typescript": "5.9.3",
+    "vitest": "^3.2.0"
   },
   "dependencies": {
     "@aws-sdk/client-cloudwatch-logs": "3.1024.0",

--- a/serverless/vitest.config.e2e.ts
+++ b/serverless/vitest.config.e2e.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from "node:fs";
+
+import { defineConfig } from "vitest/config";
+
+// Load e2e/.env.local (gitignored) for local, non-secret overrides like AWS_REGION
+// or DATADOG_CI artifact pins. Secrets (DD_API_KEY/DD_APP_KEY) should come from the
+// environment -- e.g. `aws-vault exec <profile> -- yarn test:e2e` with DD keys set.
+try {
+  for (const line of readFileSync("e2e/.env.local", "utf-8").split("\n")) {
+    const match = line.match(/^\s*([^#=]+?)\s*=\s*(.*)$/);
+    if (match && !process.env[match[1]]) {
+      let value = match[2];
+      if ((value.startsWith("'") && value.endsWith("'")) || (value.startsWith('"') && value.endsWith('"'))) {
+        value = value.slice(1, -1);
+      }
+      process.env[match[1]] = value;
+    }
+  }
+} catch {
+  // No .env.local -- rely on the ambient environment.
+}
+
+export default defineConfig({
+  test: {
+    globals: true,
+    include: ["e2e/**/*.test.ts"],
+    // Cloud lifecycle steps are slow; give tests and setup/teardown generous budgets.
+    testTimeout: 600_000,
+    hookTimeout: 900_000,
+    // The lifecycle is a single ordered stack; never parallelize across files.
+    fileParallelism: false,
+    reporters: "default",
+  },
+});

--- a/serverless/vitest.config.e2e.ts
+++ b/serverless/vitest.config.e2e.ts
@@ -16,8 +16,9 @@ try {
       process.env[match[1]] = value;
     }
   }
-} catch {
-  // No .env.local -- rely on the ambient environment.
+} catch (e) {
+  // No .env.local -- rely on the ambient environment. Surface anything else.
+  if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e;
 }
 
 export default defineConfig({

--- a/serverless/yarn.lock
+++ b/serverless/yarn.lock
@@ -850,6 +850,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@datadog/datadog-api-client@npm:1.39.0":
+  version: 1.39.0
+  resolution: "@datadog/datadog-api-client@npm:1.39.0"
+  dependencies:
+    "@types/buffer-from": "npm:^1.1.0"
+    "@types/node": "npm:*"
+    "@types/pako": "npm:^1.0.3"
+    buffer-from: "npm:^1.1.2"
+    cross-fetch: "npm:^3.1.5"
+    es6-promise: "npm:^4.2.8"
+    form-data: "npm:^4.0.0"
+    loglevel: "npm:^1.8.1"
+    pako: "npm:^2.0.4"
+  checksum: 10c0/29d3e500694040c2bedb4847efc4e0053e808e70f024bedd1e35b59cdb1230d5048a799dd9d779b479b56a60fecb2662aa106199c31702ab794fd7119ad48fd1
+  languageName: node
+  linkType: hard
+
 "@emnapi/core@npm:^1.4.3":
   version: 1.9.2
   resolution: "@emnapi/core@npm:1.9.2"
@@ -875,6 +892,188 @@ __metadata:
   dependencies:
     tslib: "npm:^2.4.0"
   checksum: 10c0/32fcfa81ab396533b2ec1f4082b1ff779a05d9c836bbbd3f4398405b0e6814c0d9503b7993130e37bc6941dbc1ded49f55e9700ae9ca4e803bab2b5bc5deb331
+  languageName: node
+  linkType: hard
+
+"@esbuild/aix-ppc64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/aix-ppc64@npm:0.27.7"
+  conditions: os=aix & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/android-arm64@npm:0.27.7"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/android-arm@npm:0.27.7"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/android-x64@npm:0.27.7"
+  conditions: os=android & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/darwin-arm64@npm:0.27.7"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/darwin-x64@npm:0.27.7"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/freebsd-arm64@npm:0.27.7"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/freebsd-x64@npm:0.27.7"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-arm64@npm:0.27.7"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-arm@npm:0.27.7"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ia32@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-ia32@npm:0.27.7"
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-loong64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-loong64@npm:0.27.7"
+  conditions: os=linux & cpu=loong64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-mips64el@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-mips64el@npm:0.27.7"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ppc64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-ppc64@npm:0.27.7"
+  conditions: os=linux & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-riscv64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-riscv64@npm:0.27.7"
+  conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-s390x@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-s390x@npm:0.27.7"
+  conditions: os=linux & cpu=s390x
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-x64@npm:0.27.7"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/netbsd-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/netbsd-arm64@npm:0.27.7"
+  conditions: os=netbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/netbsd-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/netbsd-x64@npm:0.27.7"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/openbsd-arm64@npm:0.27.7"
+  conditions: os=openbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/openbsd-x64@npm:0.27.7"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openharmony-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/openharmony-arm64@npm:0.27.7"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/sunos-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/sunos-x64@npm:0.27.7"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/win32-arm64@npm:0.27.7"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-ia32@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/win32-ia32@npm:0.27.7"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/win32-x64@npm:0.27.7"
+  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
@@ -1286,7 +1485,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/sourcemap-codec@npm:^1.4.14, @jridgewell/sourcemap-codec@npm:^1.5.0":
+"@jridgewell/sourcemap-codec@npm:^1.4.14, @jridgewell/sourcemap-codec@npm:^1.5.0, @jridgewell/sourcemap-codec@npm:^1.5.5":
   version: 1.5.5
   resolution: "@jridgewell/sourcemap-codec@npm:1.5.5"
   checksum: 10c0/f9e538f302b63c0ebc06eecb1dd9918dd4289ed36147a0ddce35d6ea4d7ebbda243cda7b2213b6a5e1d8087a298d5cf630fb2bd39329cdecb82017023f6081a0
@@ -1381,6 +1580,181 @@ __metadata:
   version: 0.2.9
   resolution: "@pkgr/core@npm:0.2.9"
   checksum: 10c0/ac8e4e8138b1a7a4ac6282873aef7389c352f1f8b577b4850778f5182e4a39a5241facbe48361fec817f56d02b51691b383010843fb08b34a8e8ea3614688fd5
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-android-arm-eabi@npm:4.62.0":
+  version: 4.62.0
+  resolution: "@rollup/rollup-android-arm-eabi@npm:4.62.0"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-android-arm64@npm:4.62.0":
+  version: 4.62.0
+  resolution: "@rollup/rollup-android-arm64@npm:4.62.0"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-darwin-arm64@npm:4.62.0":
+  version: 4.62.0
+  resolution: "@rollup/rollup-darwin-arm64@npm:4.62.0"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-darwin-x64@npm:4.62.0":
+  version: 4.62.0
+  resolution: "@rollup/rollup-darwin-x64@npm:4.62.0"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-freebsd-arm64@npm:4.62.0":
+  version: 4.62.0
+  resolution: "@rollup/rollup-freebsd-arm64@npm:4.62.0"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-freebsd-x64@npm:4.62.0":
+  version: 4.62.0
+  resolution: "@rollup/rollup-freebsd-x64@npm:4.62.0"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-arm-gnueabihf@npm:4.62.0":
+  version: 4.62.0
+  resolution: "@rollup/rollup-linux-arm-gnueabihf@npm:4.62.0"
+  conditions: os=linux & cpu=arm & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-arm-musleabihf@npm:4.62.0":
+  version: 4.62.0
+  resolution: "@rollup/rollup-linux-arm-musleabihf@npm:4.62.0"
+  conditions: os=linux & cpu=arm & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-arm64-gnu@npm:4.62.0":
+  version: 4.62.0
+  resolution: "@rollup/rollup-linux-arm64-gnu@npm:4.62.0"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-arm64-musl@npm:4.62.0":
+  version: 4.62.0
+  resolution: "@rollup/rollup-linux-arm64-musl@npm:4.62.0"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-loong64-gnu@npm:4.62.0":
+  version: 4.62.0
+  resolution: "@rollup/rollup-linux-loong64-gnu@npm:4.62.0"
+  conditions: os=linux & cpu=loong64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-loong64-musl@npm:4.62.0":
+  version: 4.62.0
+  resolution: "@rollup/rollup-linux-loong64-musl@npm:4.62.0"
+  conditions: os=linux & cpu=loong64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-ppc64-gnu@npm:4.62.0":
+  version: 4.62.0
+  resolution: "@rollup/rollup-linux-ppc64-gnu@npm:4.62.0"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-ppc64-musl@npm:4.62.0":
+  version: 4.62.0
+  resolution: "@rollup/rollup-linux-ppc64-musl@npm:4.62.0"
+  conditions: os=linux & cpu=ppc64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-riscv64-gnu@npm:4.62.0":
+  version: 4.62.0
+  resolution: "@rollup/rollup-linux-riscv64-gnu@npm:4.62.0"
+  conditions: os=linux & cpu=riscv64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-riscv64-musl@npm:4.62.0":
+  version: 4.62.0
+  resolution: "@rollup/rollup-linux-riscv64-musl@npm:4.62.0"
+  conditions: os=linux & cpu=riscv64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-s390x-gnu@npm:4.62.0":
+  version: 4.62.0
+  resolution: "@rollup/rollup-linux-s390x-gnu@npm:4.62.0"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-x64-gnu@npm:4.62.0":
+  version: 4.62.0
+  resolution: "@rollup/rollup-linux-x64-gnu@npm:4.62.0"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-x64-musl@npm:4.62.0":
+  version: 4.62.0
+  resolution: "@rollup/rollup-linux-x64-musl@npm:4.62.0"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-openbsd-x64@npm:4.62.0":
+  version: 4.62.0
+  resolution: "@rollup/rollup-openbsd-x64@npm:4.62.0"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-openharmony-arm64@npm:4.62.0":
+  version: 4.62.0
+  resolution: "@rollup/rollup-openharmony-arm64@npm:4.62.0"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-win32-arm64-msvc@npm:4.62.0":
+  version: 4.62.0
+  resolution: "@rollup/rollup-win32-arm64-msvc@npm:4.62.0"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-win32-ia32-msvc@npm:4.62.0":
+  version: 4.62.0
+  resolution: "@rollup/rollup-win32-ia32-msvc@npm:4.62.0"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-win32-x64-gnu@npm:4.62.0":
+  version: 4.62.0
+  resolution: "@rollup/rollup-win32-x64-gnu@npm:4.62.0"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-win32-x64-msvc@npm:4.62.0":
+  version: 4.62.0
+  resolution: "@rollup/rollup-win32-x64-msvc@npm:4.62.0"
+  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
@@ -1993,6 +2367,39 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/buffer-from@npm:^1.1.0":
+  version: 1.1.3
+  resolution: "@types/buffer-from@npm:1.1.3"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10c0/c8e0e3a9e24085a3af83b8c10ce1630aa3e21d6800263d4bdcb0b734afa75addc02a2ccb1d404f83ccff4619e5100219d3aaae8d558df6709c97e6c458c99e05
+  languageName: node
+  linkType: hard
+
+"@types/chai@npm:^5.2.2":
+  version: 5.2.3
+  resolution: "@types/chai@npm:5.2.3"
+  dependencies:
+    "@types/deep-eql": "npm:*"
+    assertion-error: "npm:^2.0.1"
+  checksum: 10c0/e0ef1de3b6f8045a5e473e867c8565788c444271409d155588504840ad1a53611011f85072188c2833941189400228c1745d78323dac13fcede9c2b28bacfb2f
+  languageName: node
+  linkType: hard
+
+"@types/deep-eql@npm:*":
+  version: 4.0.2
+  resolution: "@types/deep-eql@npm:4.0.2"
+  checksum: 10c0/bf3f811843117900d7084b9d0c852da9a044d12eb40e6de73b552598a6843c21291a8a381b0532644574beecd5e3491c5ff3a0365ab86b15d59862c025384844
+  languageName: node
+  linkType: hard
+
+"@types/estree@npm:1.0.9, @types/estree@npm:^1.0.0":
+  version: 1.0.9
+  resolution: "@types/estree@npm:1.0.9"
+  checksum: 10c0/3ad3286ca2988cd550dafb8f2ad599c8474868e954fa601a36655bdfefd8039f7c714b8c1c7f2ae219ffbd58bd4660e66fa7479a0120fc02d4777057d4865387
+  languageName: node
+  linkType: hard
+
 "@types/istanbul-lib-coverage@npm:*, @types/istanbul-lib-coverage@npm:^2.0.1, @types/istanbul-lib-coverage@npm:^2.0.6":
   version: 2.0.6
   resolution: "@types/istanbul-lib-coverage@npm:2.0.6"
@@ -2041,6 +2448,13 @@ __metadata:
   dependencies:
     undici-types: "npm:~7.18.0"
   checksum: 10c0/11e41a85401724cd1a4de6fb7bd4264ec46db10c09fc8cf8d41de4ede0a7063db458348f859ead4ec0929906aa26aaf45a5fef3aa59742ca0521cda9cee52377
+  languageName: node
+  linkType: hard
+
+"@types/pako@npm:^1.0.3":
+  version: 1.0.7
+  resolution: "@types/pako@npm:1.0.7"
+  checksum: 10c0/1ba133db0b30a974c3d651c85651fd30135f629727b4b4d7ef2649c8f8b01014d5ef41f75399d939e320a50bfa87c32beccbb513badfeaf85d74ea6d5370fdcc
   languageName: node
   linkType: hard
 
@@ -2339,6 +2753,89 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vitest/expect@npm:3.2.6":
+  version: 3.2.6
+  resolution: "@vitest/expect@npm:3.2.6"
+  dependencies:
+    "@types/chai": "npm:^5.2.2"
+    "@vitest/spy": "npm:3.2.6"
+    "@vitest/utils": "npm:3.2.6"
+    chai: "npm:^5.2.0"
+    tinyrainbow: "npm:^2.0.0"
+  checksum: 10c0/bb51fa6a1f0740b3ee994347bc5067c8a17c2f3dea56b76a8c2c328885cdbfbafbb99b0b94b8166dc605eedbb9f467d37a6a0e0c81855eb18e232417cca4ccbd
+  languageName: node
+  linkType: hard
+
+"@vitest/mocker@npm:3.2.6":
+  version: 3.2.6
+  resolution: "@vitest/mocker@npm:3.2.6"
+  dependencies:
+    "@vitest/spy": "npm:3.2.6"
+    estree-walker: "npm:^3.0.3"
+    magic-string: "npm:^0.30.17"
+  peerDependencies:
+    msw: ^2.4.9
+    vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+  peerDependenciesMeta:
+    msw:
+      optional: true
+    vite:
+      optional: true
+  checksum: 10c0/0429d72e52ca1cc25d7ac44fbc251d0486974d8e0e59860c605d72456c0a17fa1d464b2a5e34690c17afcc7be562d7c22595f53503244a858f1f5903998da100
+  languageName: node
+  linkType: hard
+
+"@vitest/pretty-format@npm:3.2.6, @vitest/pretty-format@npm:^3.2.6":
+  version: 3.2.6
+  resolution: "@vitest/pretty-format@npm:3.2.6"
+  dependencies:
+    tinyrainbow: "npm:^2.0.0"
+  checksum: 10c0/9fc2887ef4206c90392de4e205d0109add35382446914d0124c53d1da327f49b9e9535fb336cb260394c176e4bb14b1b3aba0a42ab12b0f8b95034ccd4fed4eb
+  languageName: node
+  linkType: hard
+
+"@vitest/runner@npm:3.2.6":
+  version: 3.2.6
+  resolution: "@vitest/runner@npm:3.2.6"
+  dependencies:
+    "@vitest/utils": "npm:3.2.6"
+    pathe: "npm:^2.0.3"
+    strip-literal: "npm:^3.0.0"
+  checksum: 10c0/bfc552ee2424ec62e4d6c075d000348a8187eb1be7ce9ae4673139c2f4a71e271ac15bef4d6af27cb5a29f4776dd437bea9d5819f62f0b5ece3c6dd857fa300d
+  languageName: node
+  linkType: hard
+
+"@vitest/snapshot@npm:3.2.6":
+  version: 3.2.6
+  resolution: "@vitest/snapshot@npm:3.2.6"
+  dependencies:
+    "@vitest/pretty-format": "npm:3.2.6"
+    magic-string: "npm:^0.30.17"
+    pathe: "npm:^2.0.3"
+  checksum: 10c0/b8f73cc2bc50ca6cd013e2dae1f531aa2132d053e52d2055da8544290e6e8a92dd06f8cf07e8fce15137f27e8156f2936eb6bd9fa63c76e6f6a9813cf0820022
+  languageName: node
+  linkType: hard
+
+"@vitest/spy@npm:3.2.6":
+  version: 3.2.6
+  resolution: "@vitest/spy@npm:3.2.6"
+  dependencies:
+    tinyspy: "npm:^4.0.3"
+  checksum: 10c0/b4b022546523168f361cd640dff68feb9709b259aacc05e12055a4f278d07e58fbb280ae70454425199f91e62729b03f0a16bdfe880c5a0b1b10c02bc334fc30
+  languageName: node
+  linkType: hard
+
+"@vitest/utils@npm:3.2.6":
+  version: 3.2.6
+  resolution: "@vitest/utils@npm:3.2.6"
+  dependencies:
+    "@vitest/pretty-format": "npm:3.2.6"
+    loupe: "npm:^3.1.4"
+    tinyrainbow: "npm:^2.0.0"
+  checksum: 10c0/452da757082ebcadf43ce697bf4077d546ea06e094763969440c3cb0d7bb950be0f69d6dbdab297cd0307bdf956294e20b0184d0218a4ef942d3d253995d44ed
+  languageName: node
+  linkType: hard
+
 "abbrev@npm:^4.0.0":
   version: 4.0.0
   resolution: "abbrev@npm:4.0.0"
@@ -2459,6 +2956,34 @@ __metadata:
   version: 2.1.0
   resolution: "array-union@npm:2.1.0"
   checksum: 10c0/429897e68110374f39b771ec47a7161fc6a8fc33e196857c0a396dc75df0b5f65e4d046674db764330b6bb66b39ef48dd7c53b6a2ee75cfb0681e0c1a7033962
+  languageName: node
+  linkType: hard
+
+"assertion-error@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "assertion-error@npm:2.0.1"
+  checksum: 10c0/bbbcb117ac6480138f8c93cf7f535614282dea9dc828f540cdece85e3c665e8f78958b96afac52f29ff883c72638e6a87d469ecc9fe5bc902df03ed24a55dba8
+  languageName: node
+  linkType: hard
+
+"async-function@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "async-function@npm:1.0.0"
+  checksum: 10c0/669a32c2cb7e45091330c680e92eaeb791bc1d4132d827591e499cd1f776ff5a873e77e5f92d0ce795a8d60f10761dec9ddfe7225a5de680f5d357f67b1aac73
+  languageName: node
+  linkType: hard
+
+"async-generator-function@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "async-generator-function@npm:1.0.0"
+  checksum: 10c0/2c50ef856c543ad500d8d8777d347e3c1ba623b93e99c9263ecc5f965c1b12d2a140e2ab6e43c3d0b85366110696f28114649411cbcd10b452a92a2318394186
+  languageName: node
+  linkType: hard
+
+"asynckit@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "asynckit@npm:0.4.0"
+  checksum: 10c0/d73e2ddf20c4eb9337e1b3df1a0f6159481050a5de457c55b14ea2e5cb6d90bb69e004c9af54737a5ee0917fcf2c9e25de67777bbe58261847846066ba75bc9d
   languageName: node
   linkType: hard
 
@@ -2638,10 +3163,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"buffer-from@npm:^1.0.0":
+"buffer-from@npm:^1.0.0, buffer-from@npm:^1.1.2":
   version: 1.1.2
   resolution: "buffer-from@npm:1.1.2"
   checksum: 10c0/124fff9d66d691a86d3b062eff4663fe437a9d9ee4b47b1b9e97f5a5d14f6d5399345db80f796827be7c95e70a8e765dd404b7c3ff3b3324f98e9b0c8826cc34
+  languageName: node
+  linkType: hard
+
+"cac@npm:^6.7.14":
+  version: 6.7.14
+  resolution: "cac@npm:6.7.14"
+  checksum: 10c0/4ee06aaa7bab8981f0d54e5f5f9d4adcd64058e9697563ce336d8a3878ed018ee18ebe5359b2430eceae87e0758e62ea2019c3f52ae6e211b1bd2e133856cd10
   languageName: node
   linkType: hard
 
@@ -2660,6 +3192,16 @@ __metadata:
     p-map: "npm:^7.0.2"
     ssri: "npm:^13.0.0"
   checksum: 10c0/539bf4020e44ba9ca5afc2ec435623ed7e0dd80c020097677e6b4a0545df5cc9d20b473212d01209c8b4aea43c0d095af0bb6da97bcb991642ea6fac0d7c462b
+  languageName: node
+  linkType: hard
+
+"call-bind-apply-helpers@npm:^1.0.1, call-bind-apply-helpers@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "call-bind-apply-helpers@npm:1.0.2"
+  dependencies:
+    es-errors: "npm:^1.3.0"
+    function-bind: "npm:^1.1.2"
+  checksum: 10c0/47bd9901d57b857590431243fea704ff18078b16890a6b3e021e12d279bbf211d039155e27d7566b374d49ee1f8189344bac9833dec7a20cdec370506361c938
   languageName: node
   linkType: hard
 
@@ -2691,6 +3233,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chai@npm:^5.2.0":
+  version: 5.3.3
+  resolution: "chai@npm:5.3.3"
+  dependencies:
+    assertion-error: "npm:^2.0.1"
+    check-error: "npm:^2.1.1"
+    deep-eql: "npm:^5.0.1"
+    loupe: "npm:^3.1.0"
+    pathval: "npm:^2.0.0"
+  checksum: 10c0/b360fd4d38861622e5010c2f709736988b05c7f31042305fa3f4e9911f6adb80ccfb4e302068bf8ed10e835c2e2520cba0f5edc13d878b886987e5aa62483f53
+  languageName: node
+  linkType: hard
+
 "chalk@npm:^4.0.0, chalk@npm:^4.1.2":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
@@ -2705,6 +3260,13 @@ __metadata:
   version: 1.0.2
   resolution: "char-regex@npm:1.0.2"
   checksum: 10c0/57a09a86371331e0be35d9083ba429e86c4f4648ecbe27455dbfb343037c16ee6fdc7f6b61f433a57cc5ded5561d71c56a150e018f40c2ffb7bc93a26dae341e
+  languageName: node
+  linkType: hard
+
+"check-error@npm:^2.1.1":
+  version: 2.1.3
+  resolution: "check-error@npm:2.1.3"
+  checksum: 10c0/878e99038fb6476316b74668cd6a498c7e66df3efe48158fa40db80a06ba4258742ac3ee2229c4a2a98c5e73f5dff84eb3e50ceb6b65bbd8f831eafc8338607d
   languageName: node
   linkType: hard
 
@@ -2770,6 +3332,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"combined-stream@npm:^1.0.8":
+  version: 1.0.8
+  resolution: "combined-stream@npm:1.0.8"
+  dependencies:
+    delayed-stream: "npm:~1.0.0"
+  checksum: 10c0/0dbb829577e1b1e839fa82b40c07ffaf7de8a09b935cadd355a73652ae70a88b4320db322f6634a4ad93424292fa80973ac6480986247f1734a1137debf271d5
+  languageName: node
+  linkType: hard
+
 "concat-map@npm:0.0.1":
   version: 0.0.1
   resolution: "concat-map@npm:0.0.1"
@@ -2781,6 +3352,15 @@ __metadata:
   version: 2.0.0
   resolution: "convert-source-map@npm:2.0.0"
   checksum: 10c0/8f2f7a27a1a011cc6cc88cc4da2d7d0cfa5ee0369508baae3d98c260bb3ac520691464e5bbe4ae7cdf09860c1d69ecc6f70c63c6e7c7f7e3f18ec08484dc7d9b
+  languageName: node
+  linkType: hard
+
+"cross-fetch@npm:^3.1.5":
+  version: 3.2.0
+  resolution: "cross-fetch@npm:3.2.0"
+  dependencies:
+    node-fetch: "npm:^2.7.0"
+  checksum: 10c0/d8596adf0269130098a676f6739a0922f3cc7b71cc89729925411ebe851a87026171c82ea89154c4811c9867c01c44793205a52e618ce2684650218c7fbeeb9f
   languageName: node
   linkType: hard
 
@@ -2800,6 +3380,7 @@ __metadata:
   resolution: "datadog-serverless-macro@workspace:."
   dependencies:
     "@aws-sdk/client-cloudwatch-logs": "npm:3.1024.0"
+    "@datadog/datadog-api-client": "npm:1.39.0"
     "@types/jest": "npm:30.0.0"
     "@types/node": "npm:25.5.2"
     "@typescript-eslint/eslint-plugin": "npm:6.21.0"
@@ -2810,10 +3391,11 @@ __metadata:
     prettier: "npm:3.8.1"
     ts-jest: "npm:29.4.9"
     typescript: "npm:5.9.3"
+    vitest: "npm:^3.2.0"
   languageName: unknown
   linkType: soft
 
-"debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4":
+"debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.4.1":
   version: 4.4.3
   resolution: "debug@npm:4.4.3"
   dependencies:
@@ -2837,6 +3419,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"deep-eql@npm:^5.0.1":
+  version: 5.0.2
+  resolution: "deep-eql@npm:5.0.2"
+  checksum: 10c0/7102cf3b7bb719c6b9c0db2e19bf0aa9318d141581befe8c7ce8ccd39af9eaa4346e5e05adef7f9bd7015da0f13a3a25dcfe306ef79dc8668aedbecb658dd247
+  languageName: node
+  linkType: hard
+
 "deep-is@npm:^0.1.3":
   version: 0.1.4
   resolution: "deep-is@npm:0.1.4"
@@ -2848,6 +3437,13 @@ __metadata:
   version: 4.3.1
   resolution: "deepmerge@npm:4.3.1"
   checksum: 10c0/e53481aaf1aa2c4082b5342be6b6d8ad9dfe387bc92ce197a66dea08bd4265904a087e75e464f14d1347cf2ac8afe1e4c16b266e0561cc5df29382d3c5f80044
+  languageName: node
+  linkType: hard
+
+"delayed-stream@npm:~1.0.0":
+  version: 1.0.0
+  resolution: "delayed-stream@npm:1.0.0"
+  checksum: 10c0/d758899da03392e6712f042bec80aa293bbe9e9ff1b2634baae6a360113e708b91326594c8a486d475c69d6259afb7efacdc3537bfcda1c6c648e390ce601b19
   languageName: node
   linkType: hard
 
@@ -2873,6 +3469,17 @@ __metadata:
   dependencies:
     esutils: "npm:^2.0.2"
   checksum: 10c0/c96bdccabe9d62ab6fea9399fdff04a66e6563c1d6fb3a3a063e8d53c3bb136ba63e84250bbf63d00086a769ad53aef92d2bd483f03f837fc97b71cbee6b2520
+  languageName: node
+  linkType: hard
+
+"dunder-proto@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "dunder-proto@npm:1.0.1"
+  dependencies:
+    call-bind-apply-helpers: "npm:^1.0.1"
+    es-errors: "npm:^1.3.0"
+    gopd: "npm:^1.2.0"
+  checksum: 10c0/199f2a0c1c16593ca0a145dbf76a962f8033ce3129f01284d48c45ed4e14fea9bbacd7b3610b6cdc33486cef20385ac054948fefc6272fcce645c09468f93031
   languageName: node
   linkType: hard
 
@@ -2924,6 +3531,144 @@ __metadata:
   dependencies:
     is-arrayish: "npm:^0.2.1"
   checksum: 10c0/b9e34ff4778b8f3b31a8377e1c654456f4c41aeaa3d10a1138c3b7635d8b7b2e03eb2475d46d8ae055c1f180a1063e100bffabf64ea7e7388b37735df5328664
+  languageName: node
+  linkType: hard
+
+"es-define-property@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "es-define-property@npm:1.0.1"
+  checksum: 10c0/3f54eb49c16c18707949ff25a1456728c883e81259f045003499efba399c08bad00deebf65cccde8c0e07908c1a225c9d472b7107e558f2a48e28d530e34527c
+  languageName: node
+  linkType: hard
+
+"es-errors@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "es-errors@npm:1.3.0"
+  checksum: 10c0/0a61325670072f98d8ae3b914edab3559b6caa980f08054a3b872052640d91da01d38df55df797fcc916389d77fc92b8d5906cf028f4db46d7e3003abecbca85
+  languageName: node
+  linkType: hard
+
+"es-module-lexer@npm:^1.7.0":
+  version: 1.7.0
+  resolution: "es-module-lexer@npm:1.7.0"
+  checksum: 10c0/4c935affcbfeba7fb4533e1da10fa8568043df1e3574b869385980de9e2d475ddc36769891936dbb07036edb3c3786a8b78ccf44964cd130dedc1f2c984b6c7b
+  languageName: node
+  linkType: hard
+
+"es-object-atoms@npm:^1.0.0, es-object-atoms@npm:^1.1.1":
+  version: 1.1.2
+  resolution: "es-object-atoms@npm:1.1.2"
+  dependencies:
+    es-errors: "npm:^1.3.0"
+  checksum: 10c0/1772861f094f739d6f41b579cfb9a18579daffeb434552a370a5fbef50a32d22227e27b63fdbb757b7ddd429d1b42fe52ccae7966d9302a2ec221b6f1b41bbc4
+  languageName: node
+  linkType: hard
+
+"es-set-tostringtag@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "es-set-tostringtag@npm:2.1.0"
+  dependencies:
+    es-errors: "npm:^1.3.0"
+    get-intrinsic: "npm:^1.2.6"
+    has-tostringtag: "npm:^1.0.2"
+    hasown: "npm:^2.0.2"
+  checksum: 10c0/ef2ca9ce49afe3931cb32e35da4dcb6d86ab02592cfc2ce3e49ced199d9d0bb5085fc7e73e06312213765f5efa47cc1df553a6a5154584b21448e9fb8355b1af
+  languageName: node
+  linkType: hard
+
+"es6-promise@npm:^4.2.8":
+  version: 4.2.8
+  resolution: "es6-promise@npm:4.2.8"
+  checksum: 10c0/2373d9c5e9a93bdd9f9ed32ff5cb6dd3dd785368d1c21e9bbbfd07d16345b3774ae260f2bd24c8f836a6903f432b4151e7816a7fa8891ccb4e1a55a028ec42c3
+  languageName: node
+  linkType: hard
+
+"esbuild@npm:^0.27.0":
+  version: 0.27.7
+  resolution: "esbuild@npm:0.27.7"
+  dependencies:
+    "@esbuild/aix-ppc64": "npm:0.27.7"
+    "@esbuild/android-arm": "npm:0.27.7"
+    "@esbuild/android-arm64": "npm:0.27.7"
+    "@esbuild/android-x64": "npm:0.27.7"
+    "@esbuild/darwin-arm64": "npm:0.27.7"
+    "@esbuild/darwin-x64": "npm:0.27.7"
+    "@esbuild/freebsd-arm64": "npm:0.27.7"
+    "@esbuild/freebsd-x64": "npm:0.27.7"
+    "@esbuild/linux-arm": "npm:0.27.7"
+    "@esbuild/linux-arm64": "npm:0.27.7"
+    "@esbuild/linux-ia32": "npm:0.27.7"
+    "@esbuild/linux-loong64": "npm:0.27.7"
+    "@esbuild/linux-mips64el": "npm:0.27.7"
+    "@esbuild/linux-ppc64": "npm:0.27.7"
+    "@esbuild/linux-riscv64": "npm:0.27.7"
+    "@esbuild/linux-s390x": "npm:0.27.7"
+    "@esbuild/linux-x64": "npm:0.27.7"
+    "@esbuild/netbsd-arm64": "npm:0.27.7"
+    "@esbuild/netbsd-x64": "npm:0.27.7"
+    "@esbuild/openbsd-arm64": "npm:0.27.7"
+    "@esbuild/openbsd-x64": "npm:0.27.7"
+    "@esbuild/openharmony-arm64": "npm:0.27.7"
+    "@esbuild/sunos-x64": "npm:0.27.7"
+    "@esbuild/win32-arm64": "npm:0.27.7"
+    "@esbuild/win32-ia32": "npm:0.27.7"
+    "@esbuild/win32-x64": "npm:0.27.7"
+  dependenciesMeta:
+    "@esbuild/aix-ppc64":
+      optional: true
+    "@esbuild/android-arm":
+      optional: true
+    "@esbuild/android-arm64":
+      optional: true
+    "@esbuild/android-x64":
+      optional: true
+    "@esbuild/darwin-arm64":
+      optional: true
+    "@esbuild/darwin-x64":
+      optional: true
+    "@esbuild/freebsd-arm64":
+      optional: true
+    "@esbuild/freebsd-x64":
+      optional: true
+    "@esbuild/linux-arm":
+      optional: true
+    "@esbuild/linux-arm64":
+      optional: true
+    "@esbuild/linux-ia32":
+      optional: true
+    "@esbuild/linux-loong64":
+      optional: true
+    "@esbuild/linux-mips64el":
+      optional: true
+    "@esbuild/linux-ppc64":
+      optional: true
+    "@esbuild/linux-riscv64":
+      optional: true
+    "@esbuild/linux-s390x":
+      optional: true
+    "@esbuild/linux-x64":
+      optional: true
+    "@esbuild/netbsd-arm64":
+      optional: true
+    "@esbuild/netbsd-x64":
+      optional: true
+    "@esbuild/openbsd-arm64":
+      optional: true
+    "@esbuild/openbsd-x64":
+      optional: true
+    "@esbuild/openharmony-arm64":
+      optional: true
+    "@esbuild/sunos-x64":
+      optional: true
+    "@esbuild/win32-arm64":
+      optional: true
+    "@esbuild/win32-ia32":
+      optional: true
+    "@esbuild/win32-x64":
+      optional: true
+  bin:
+    esbuild: bin/esbuild
+  checksum: 10c0/ccd51f0555708bc9ff4ec9dc3ac92d3daacd45ecaac949ca8645984c5c323bf8cefe98c2df307418685e0b4ce37f9a3bdbfe8e3651fe632a0059a436195a17d4
   languageName: node
   linkType: hard
 
@@ -3059,6 +3804,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"estree-walker@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "estree-walker@npm:3.0.3"
+  dependencies:
+    "@types/estree": "npm:^1.0.0"
+  checksum: 10c0/c12e3c2b2642d2bcae7d5aa495c60fa2f299160946535763969a1c83fc74518ffa9c2cd3a8b69ac56aea547df6a8aac25f729a342992ef0bbac5f1c73e78995d
+  languageName: node
+  linkType: hard
+
 "esutils@npm:^2.0.2":
   version: 2.0.3
   resolution: "esutils@npm:2.0.3"
@@ -3087,6 +3841,13 @@ __metadata:
   version: 0.2.2
   resolution: "exit-x@npm:0.2.2"
   checksum: 10c0/212a7a095ca5540e9581f1ef2d1d6a40df7a6027c8cc96e78ce1d16b86d1a88326d4a0eff8dff2b5ec1e68bb0c1edd5d0dfdde87df1869bf7514d4bc6a5cbd72
+  languageName: node
+  linkType: hard
+
+"expect-type@npm:^1.2.1":
+  version: 1.3.0
+  resolution: "expect-type@npm:1.3.0"
+  checksum: 10c0/8412b3fe4f392c420ab41dae220b09700e4e47c639a29ba7ba2e83cc6cffd2b4926f7ac9e47d7e277e8f4f02acda76fd6931cb81fd2b382fa9477ef9ada953fd
   languageName: node
   linkType: hard
 
@@ -3263,6 +4024,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"form-data@npm:^4.0.0":
+  version: 4.0.6
+  resolution: "form-data@npm:4.0.6"
+  dependencies:
+    asynckit: "npm:^0.4.0"
+    combined-stream: "npm:^1.0.8"
+    es-set-tostringtag: "npm:^2.1.0"
+    hasown: "npm:^2.0.4"
+    mime-types: "npm:^2.1.35"
+  checksum: 10c0/43947a77bf0ff45c6ceed789778982d47a3f3e720a74b71721174ebf3310a5f1a8be1d6b38a3ee3688e8a18a2c4273073ec0844cd37efda3eaf46d41c9c318ff
+  languageName: node
+  linkType: hard
+
 "fs-minipass@npm:^3.0.0":
   version: 3.0.3
   resolution: "fs-minipass@npm:3.0.3"
@@ -3279,7 +4053,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@npm:^2.3.3":
+"fsevents@npm:^2.3.3, fsevents@npm:~2.3.2, fsevents@npm:~2.3.3":
   version: 2.3.3
   resolution: "fsevents@npm:2.3.3"
   dependencies:
@@ -3289,12 +4063,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@patch:fsevents@npm%3A^2.3.3#optional!builtin<compat/fsevents>":
+"fsevents@patch:fsevents@npm%3A^2.3.3#optional!builtin<compat/fsevents>, fsevents@patch:fsevents@npm%3A~2.3.2#optional!builtin<compat/fsevents>, fsevents@patch:fsevents@npm%3A~2.3.3#optional!builtin<compat/fsevents>":
   version: 2.3.3
   resolution: "fsevents@patch:fsevents@npm%3A2.3.3#optional!builtin<compat/fsevents>::version=2.3.3&hash=df0bf1"
   dependencies:
     node-gyp: "npm:latest"
   conditions: os=darwin
+  languageName: node
+  linkType: hard
+
+"function-bind@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "function-bind@npm:1.1.2"
+  checksum: 10c0/d8680ee1e5fcd4c197e4ac33b2b4dce03c71f4d91717292785703db200f5c21f977c568d28061226f9b5900cbcd2c84463646134fd5337e7925e0942bc3f46d5
+  languageName: node
+  linkType: hard
+
+"generator-function@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "generator-function@npm:2.0.1"
+  checksum: 10c0/8a9f59df0f01cfefafdb3b451b80555e5cf6d76487095db91ac461a0e682e4ff7a9dbce15f4ecec191e53586d59eece01949e05a4b4492879600bbbe8e28d6b8
   languageName: node
   linkType: hard
 
@@ -3312,10 +4100,41 @@ __metadata:
   languageName: node
   linkType: hard
 
+"get-intrinsic@npm:^1.2.6":
+  version: 1.3.1
+  resolution: "get-intrinsic@npm:1.3.1"
+  dependencies:
+    async-function: "npm:^1.0.0"
+    async-generator-function: "npm:^1.0.0"
+    call-bind-apply-helpers: "npm:^1.0.2"
+    es-define-property: "npm:^1.0.1"
+    es-errors: "npm:^1.3.0"
+    es-object-atoms: "npm:^1.1.1"
+    function-bind: "npm:^1.1.2"
+    generator-function: "npm:^2.0.0"
+    get-proto: "npm:^1.0.1"
+    gopd: "npm:^1.2.0"
+    has-symbols: "npm:^1.1.0"
+    hasown: "npm:^2.0.2"
+    math-intrinsics: "npm:^1.1.0"
+  checksum: 10c0/9f4ab0cf7efe0fd2c8185f52e6f637e708f3a112610c88869f8f041bb9ecc2ce44bf285dfdbdc6f4f7c277a5b88d8e94a432374d97cca22f3de7fc63795deb5d
+  languageName: node
+  linkType: hard
+
 "get-package-type@npm:^0.1.0":
   version: 0.1.0
   resolution: "get-package-type@npm:0.1.0"
   checksum: 10c0/e34cdf447fdf1902a1f6d5af737eaadf606d2ee3518287abde8910e04159368c268568174b2e71102b87b26c2020486f126bfca9c4fb1ceb986ff99b52ecd1be
+  languageName: node
+  linkType: hard
+
+"get-proto@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "get-proto@npm:1.0.1"
+  dependencies:
+    dunder-proto: "npm:^1.0.1"
+    es-object-atoms: "npm:^1.0.0"
+  checksum: 10c0/9224acb44603c5526955e83510b9da41baf6ae73f7398875fba50edc5e944223a89c4a72b070fcd78beb5f7bdda58ecb6294adc28f7acfc0da05f76a2399643c
   languageName: node
   linkType: hard
 
@@ -3408,6 +4227,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"gopd@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "gopd@npm:1.2.0"
+  checksum: 10c0/50fff1e04ba2b7737c097358534eacadad1e68d24cccee3272e04e007bed008e68d2614f3987788428fd192a5ae3889d08fb2331417e4fc4a9ab366b2043cead
+  languageName: node
+  linkType: hard
+
 "graceful-fs@npm:^4.2.11, graceful-fs@npm:^4.2.6":
   version: 4.2.11
   resolution: "graceful-fs@npm:4.2.11"
@@ -3444,6 +4270,31 @@ __metadata:
   version: 4.0.0
   resolution: "has-flag@npm:4.0.0"
   checksum: 10c0/2e789c61b7888d66993e14e8331449e525ef42aac53c627cc53d1c3334e768bcb6abdc4f5f0de1478a25beec6f0bd62c7549058b7ac53e924040d4f301f02fd1
+  languageName: node
+  linkType: hard
+
+"has-symbols@npm:^1.0.3, has-symbols@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "has-symbols@npm:1.1.0"
+  checksum: 10c0/dde0a734b17ae51e84b10986e651c664379018d10b91b6b0e9b293eddb32f0f069688c841fb40f19e9611546130153e0a2a48fd7f512891fb000ddfa36f5a20e
+  languageName: node
+  linkType: hard
+
+"has-tostringtag@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "has-tostringtag@npm:1.0.2"
+  dependencies:
+    has-symbols: "npm:^1.0.3"
+  checksum: 10c0/a8b166462192bafe3d9b6e420a1d581d93dd867adb61be223a17a8d6dad147aa77a8be32c961bb2f27b3ef893cae8d36f564ab651f5e9b7938ae86f74027c48c
+  languageName: node
+  linkType: hard
+
+"hasown@npm:^2.0.2, hasown@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "hasown@npm:2.0.4"
+  dependencies:
+    function-bind: "npm:^1.1.2"
+  checksum: 10c0/2d8de939e270b70618f8cebb69746620db10617dbb495bc66ddad326955ea24d3ca4af133aff3eb7c1853e0218f867bc2b050ec26fe02e3aea58f880ffc5e506
   languageName: node
   linkType: hard
 
@@ -4138,6 +4989,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"js-tokens@npm:^9.0.1":
+  version: 9.0.1
+  resolution: "js-tokens@npm:9.0.1"
+  checksum: 10c0/68dcab8f233dde211a6b5fd98079783cbcd04b53617c1250e3553ee16ab3e6134f5e65478e41d82f6d351a052a63d71024553933808570f04dbf828d7921e80e
+  languageName: node
+  linkType: hard
+
 "js-yaml@npm:^3.13.1":
   version: 3.14.2
   resolution: "js-yaml@npm:3.14.2"
@@ -4272,10 +5130,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"loglevel@npm:1.9.2":
+"loglevel@npm:1.9.2, loglevel@npm:^1.8.1":
   version: 1.9.2
   resolution: "loglevel@npm:1.9.2"
   checksum: 10c0/1e317fa4648fe0b4a4cffef6de037340592cee8547b07d4ce97a487abe9153e704b98451100c799b032c72bb89c9366d71c9fb8192ada8703269263ae77acdc7
+  languageName: node
+  linkType: hard
+
+"loupe@npm:^3.1.0, loupe@npm:^3.1.4":
+  version: 3.2.1
+  resolution: "loupe@npm:3.2.1"
+  checksum: 10c0/910c872cba291309664c2d094368d31a68907b6f5913e989d301b5c25f30e97d76d77f23ab3bf3b46d0f601ff0b6af8810c10c31b91d2c6b2f132809ca2cc705
   languageName: node
   linkType: hard
 
@@ -4299,6 +5164,15 @@ __metadata:
   dependencies:
     yallist: "npm:^3.0.2"
   checksum: 10c0/89b2ef2ef45f543011e38737b8a8622a2f8998cddf0e5437174ef8f1f70a8b9d14a918ab3e232cb3ba343b7abddffa667f0b59075b2b80e6b4d63c3de6127482
+  languageName: node
+  linkType: hard
+
+"magic-string@npm:^0.30.17":
+  version: 0.30.21
+  resolution: "magic-string@npm:0.30.21"
+  dependencies:
+    "@jridgewell/sourcemap-codec": "npm:^1.5.5"
+  checksum: 10c0/299378e38f9a270069fc62358522ddfb44e94244baa0d6a8980ab2a9b2490a1d03b236b447eee309e17eb3bddfa482c61259d47960eb018a904f0ded52780c4a
   languageName: node
   linkType: hard
 
@@ -4347,6 +5221,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"math-intrinsics@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "math-intrinsics@npm:1.1.0"
+  checksum: 10c0/7579ff94e899e2f76ab64491d76cf606274c874d8f2af4a442c016bd85688927fcfca157ba6bf74b08e9439dc010b248ce05b96cc7c126a354c3bae7fcb48b7f
+  languageName: node
+  linkType: hard
+
 "merge-stream@npm:^2.0.0":
   version: 2.0.0
   resolution: "merge-stream@npm:2.0.0"
@@ -4368,6 +5249,22 @@ __metadata:
     braces: "npm:^3.0.3"
     picomatch: "npm:^2.3.1"
   checksum: 10c0/166fa6eb926b9553f32ef81f5f531d27b4ce7da60e5baf8c021d043b27a388fb95e46a8038d5045877881e673f8134122b59624d5cecbd16eb50a42e7a6b5ca8
+  languageName: node
+  linkType: hard
+
+"mime-db@npm:1.52.0":
+  version: 1.52.0
+  resolution: "mime-db@npm:1.52.0"
+  checksum: 10c0/0557a01deebf45ac5f5777fe7740b2a5c309c6d62d40ceab4e23da9f821899ce7a900b7ac8157d4548ddbb7beffe9abc621250e6d182b0397ec7f10c7b91a5aa
+  languageName: node
+  linkType: hard
+
+"mime-types@npm:^2.1.35":
+  version: 2.1.35
+  resolution: "mime-types@npm:2.1.35"
+  dependencies:
+    mime-db: "npm:1.52.0"
+  checksum: 10c0/82fb07ec56d8ff1fc999a84f2f217aa46cb6ed1033fefaabd5785b9a974ed225c90dc72fff460259e66b95b73648596dbcc50d51ed69cdf464af2d237d3149b2
   languageName: node
   linkType: hard
 
@@ -4504,6 +5401,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nanoid@npm:^3.3.12":
+  version: 3.3.12
+  resolution: "nanoid@npm:3.3.12"
+  bin:
+    nanoid: bin/nanoid.cjs
+  checksum: 10c0/ba142b7b39e11e80c16dd74b0365d407880c87c1cf7e1480956981ae940ee36060fa5b6f092cd1e315184dd19244c657bd017d03327bd3c62247d691c5e8edfb
+  languageName: node
+  linkType: hard
+
 "napi-postinstall@npm:^0.3.0":
   version: 0.3.4
   resolution: "napi-postinstall@npm:0.3.4"
@@ -4531,6 +5437,20 @@ __metadata:
   version: 2.6.2
   resolution: "neo-async@npm:2.6.2"
   checksum: 10c0/c2f5a604a54a8ec5438a342e1f356dff4bc33ccccdb6dc668d94fe8e5eccfc9d2c2eea6064b0967a767ba63b33763f51ccf2cd2441b461a7322656c1f06b3f5d
+  languageName: node
+  linkType: hard
+
+"node-fetch@npm:^2.7.0":
+  version: 2.7.0
+  resolution: "node-fetch@npm:2.7.0"
+  dependencies:
+    whatwg-url: "npm:^5.0.0"
+  peerDependencies:
+    encoding: ^0.1.0
+  peerDependenciesMeta:
+    encoding:
+      optional: true
+  checksum: 10c0/b55786b6028208e6fbe594ccccc213cab67a72899c9234eb59dba51062a299ea853210fcf526998eaa2867b0963ad72338824450905679ff0fa304b8c5093ae8
   languageName: node
   linkType: hard
 
@@ -4684,6 +5604,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pako@npm:^2.0.4":
+  version: 2.1.0
+  resolution: "pako@npm:2.1.0"
+  checksum: 10c0/8e8646581410654b50eb22a5dfd71159cae98145bd5086c9a7a816ec0370b5f72b4648d08674624b3870a521e6a3daffd6c2f7bc00fdefc7063c9d8232ff5116
+  languageName: node
+  linkType: hard
+
 "parent-module@npm:^1.0.0":
   version: 1.0.1
   resolution: "parent-module@npm:1.0.1"
@@ -4760,6 +5687,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pathe@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "pathe@npm:2.0.3"
+  checksum: 10c0/c118dc5a8b5c4166011b2b70608762e260085180bb9e33e80a50dcdb1e78c010b1624f4280c492c92b05fc276715a4c357d1f9edc570f8f1b3d90b6839ebaca1
+  languageName: node
+  linkType: hard
+
+"pathval@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "pathval@npm:2.0.1"
+  checksum: 10c0/460f4709479fbf2c45903a65655fc8f0a5f6d808f989173aeef5fdea4ff4f303dc13f7870303999add60ec49d4c14733895c0a869392e9866f1091fa64fd7581
+  languageName: node
+  linkType: hard
+
 "picocolors@npm:^1.1.1":
   version: 1.1.1
   resolution: "picocolors@npm:1.1.1"
@@ -4774,7 +5715,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^4.0.3":
+"picomatch@npm:^4.0.2, picomatch@npm:^4.0.3, picomatch@npm:^4.0.4":
   version: 4.0.4
   resolution: "picomatch@npm:4.0.4"
   checksum: 10c0/e2c6023372cc7b5764719a5ffb9da0f8e781212fa7ca4bd0562db929df8e117460f00dff3cb7509dacfc06b86de924b247f504d0ce1806a37fac4633081466b0
@@ -4794,6 +5735,17 @@ __metadata:
   dependencies:
     find-up: "npm:^4.0.0"
   checksum: 10c0/c56bda7769e04907a88423feb320babaed0711af8c436ce3e56763ab1021ba107c7b0cafb11cde7529f669cfc22bffcaebffb573645cbd63842ea9fb17cd7728
+  languageName: node
+  linkType: hard
+
+"postcss@npm:^8.5.6":
+  version: 8.5.15
+  resolution: "postcss@npm:8.5.15"
+  dependencies:
+    nanoid: "npm:^3.3.12"
+    picocolors: "npm:^1.1.1"
+    source-map-js: "npm:^1.2.1"
+  checksum: 10c0/7f2e63ae22fbe43aace1bf652bd99da4e90737c64194d49e51ddc9cd0f9e51ff2861a7d734379b494deffa03a880a5c65eec70bc29ee9ebaa7136dde3eee8f31
   languageName: node
   linkType: hard
 
@@ -4907,6 +5859,96 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rollup@npm:^4.43.0":
+  version: 4.62.0
+  resolution: "rollup@npm:4.62.0"
+  dependencies:
+    "@rollup/rollup-android-arm-eabi": "npm:4.62.0"
+    "@rollup/rollup-android-arm64": "npm:4.62.0"
+    "@rollup/rollup-darwin-arm64": "npm:4.62.0"
+    "@rollup/rollup-darwin-x64": "npm:4.62.0"
+    "@rollup/rollup-freebsd-arm64": "npm:4.62.0"
+    "@rollup/rollup-freebsd-x64": "npm:4.62.0"
+    "@rollup/rollup-linux-arm-gnueabihf": "npm:4.62.0"
+    "@rollup/rollup-linux-arm-musleabihf": "npm:4.62.0"
+    "@rollup/rollup-linux-arm64-gnu": "npm:4.62.0"
+    "@rollup/rollup-linux-arm64-musl": "npm:4.62.0"
+    "@rollup/rollup-linux-loong64-gnu": "npm:4.62.0"
+    "@rollup/rollup-linux-loong64-musl": "npm:4.62.0"
+    "@rollup/rollup-linux-ppc64-gnu": "npm:4.62.0"
+    "@rollup/rollup-linux-ppc64-musl": "npm:4.62.0"
+    "@rollup/rollup-linux-riscv64-gnu": "npm:4.62.0"
+    "@rollup/rollup-linux-riscv64-musl": "npm:4.62.0"
+    "@rollup/rollup-linux-s390x-gnu": "npm:4.62.0"
+    "@rollup/rollup-linux-x64-gnu": "npm:4.62.0"
+    "@rollup/rollup-linux-x64-musl": "npm:4.62.0"
+    "@rollup/rollup-openbsd-x64": "npm:4.62.0"
+    "@rollup/rollup-openharmony-arm64": "npm:4.62.0"
+    "@rollup/rollup-win32-arm64-msvc": "npm:4.62.0"
+    "@rollup/rollup-win32-ia32-msvc": "npm:4.62.0"
+    "@rollup/rollup-win32-x64-gnu": "npm:4.62.0"
+    "@rollup/rollup-win32-x64-msvc": "npm:4.62.0"
+    "@types/estree": "npm:1.0.9"
+    fsevents: "npm:~2.3.2"
+  dependenciesMeta:
+    "@rollup/rollup-android-arm-eabi":
+      optional: true
+    "@rollup/rollup-android-arm64":
+      optional: true
+    "@rollup/rollup-darwin-arm64":
+      optional: true
+    "@rollup/rollup-darwin-x64":
+      optional: true
+    "@rollup/rollup-freebsd-arm64":
+      optional: true
+    "@rollup/rollup-freebsd-x64":
+      optional: true
+    "@rollup/rollup-linux-arm-gnueabihf":
+      optional: true
+    "@rollup/rollup-linux-arm-musleabihf":
+      optional: true
+    "@rollup/rollup-linux-arm64-gnu":
+      optional: true
+    "@rollup/rollup-linux-arm64-musl":
+      optional: true
+    "@rollup/rollup-linux-loong64-gnu":
+      optional: true
+    "@rollup/rollup-linux-loong64-musl":
+      optional: true
+    "@rollup/rollup-linux-ppc64-gnu":
+      optional: true
+    "@rollup/rollup-linux-ppc64-musl":
+      optional: true
+    "@rollup/rollup-linux-riscv64-gnu":
+      optional: true
+    "@rollup/rollup-linux-riscv64-musl":
+      optional: true
+    "@rollup/rollup-linux-s390x-gnu":
+      optional: true
+    "@rollup/rollup-linux-x64-gnu":
+      optional: true
+    "@rollup/rollup-linux-x64-musl":
+      optional: true
+    "@rollup/rollup-openbsd-x64":
+      optional: true
+    "@rollup/rollup-openharmony-arm64":
+      optional: true
+    "@rollup/rollup-win32-arm64-msvc":
+      optional: true
+    "@rollup/rollup-win32-ia32-msvc":
+      optional: true
+    "@rollup/rollup-win32-x64-gnu":
+      optional: true
+    "@rollup/rollup-win32-x64-msvc":
+      optional: true
+    fsevents:
+      optional: true
+  bin:
+    rollup: dist/bin/rollup
+  checksum: 10c0/0baa149f615152c0f86c44b237674cbac31d945ab721c257f73a844cc43d04a0f8613edbda4eaa2a376285286eac12e4f27060fc88a8f504f4ed235f6fc9b10f
+  languageName: node
+  linkType: hard
+
 "run-parallel@npm:^1.1.9":
   version: 1.2.0
   resolution: "run-parallel@npm:1.2.0"
@@ -4954,6 +5996,13 @@ __metadata:
   version: 3.0.0
   resolution: "shebang-regex@npm:3.0.0"
   checksum: 10c0/1dbed0726dd0e1152a92696c76c7f06084eb32a90f0528d11acd764043aacf76994b2fb30aa1291a21bd019d6699164d048286309a278855ee7bec06cf6fb690
+  languageName: node
+  linkType: hard
+
+"siginfo@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "siginfo@npm:2.0.0"
+  checksum: 10c0/3def8f8e516fbb34cb6ae415b07ccc5d9c018d85b4b8611e3dc6f8be6d1899f693a4382913c9ed51a06babb5201639d76453ab297d1c54a456544acf5c892e34
   languageName: node
   linkType: hard
 
@@ -5006,6 +6055,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"source-map-js@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "source-map-js@npm:1.2.1"
+  checksum: 10c0/7bda1fc4c197e3c6ff17de1b8b2c20e60af81b63a52cb32ec5a5d67a20a7d42651e2cb34ebe93833c5a2a084377e17455854fee3e21e7925c64a51b6a52b0faf
+  languageName: node
+  linkType: hard
+
 "source-map-support@npm:0.5.13":
   version: 0.5.13
   resolution: "source-map-support@npm:0.5.13"
@@ -5045,6 +6101,20 @@ __metadata:
   dependencies:
     escape-string-regexp: "npm:^2.0.0"
   checksum: 10c0/651c9f87667e077584bbe848acaecc6049bc71979f1e9a46c7b920cad4431c388df0f51b8ad7cfd6eed3db97a2878d0fc8b3122979439ea8bac29c61c95eec8a
+  languageName: node
+  linkType: hard
+
+"stackback@npm:0.0.2":
+  version: 0.0.2
+  resolution: "stackback@npm:0.0.2"
+  checksum: 10c0/89a1416668f950236dd5ac9f9a6b2588e1b9b62b1b6ad8dff1bfc5d1a15dbf0aafc9b52d2226d00c28dffff212da464eaeebfc6b7578b9d180cef3e3782c5983
+  languageName: node
+  linkType: hard
+
+"std-env@npm:^3.9.0":
+  version: 3.10.0
+  resolution: "std-env@npm:3.10.0"
+  checksum: 10c0/1814927a45004d36dde6707eaf17552a546769bc79a6421be2c16ce77d238158dfe5de30910b78ec30d95135cc1c59ea73ee22d2ca170f8b9753f84da34c427f
   languageName: node
   linkType: hard
 
@@ -5119,6 +6189,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"strip-literal@npm:^3.0.0":
+  version: 3.1.0
+  resolution: "strip-literal@npm:3.1.0"
+  dependencies:
+    js-tokens: "npm:^9.0.1"
+  checksum: 10c0/50918f669915d9ad0fe4b7599902b735f853f2201c97791ead00104a654259c0c61bc2bc8fa3db05109339b61f4cf09e47b94ecc874ffbd0e013965223893af8
+  languageName: node
+  linkType: hard
+
 "strnum@npm:^2.2.0":
   version: 2.2.2
   resolution: "strnum@npm:2.2.2"
@@ -5184,6 +6263,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tinybench@npm:^2.9.0":
+  version: 2.9.0
+  resolution: "tinybench@npm:2.9.0"
+  checksum: 10c0/c3500b0f60d2eb8db65250afe750b66d51623057ee88720b7f064894a6cb7eb93360ca824a60a31ab16dab30c7b1f06efe0795b352e37914a9d4bad86386a20c
+  languageName: node
+  linkType: hard
+
+"tinyexec@npm:^0.3.2":
+  version: 0.3.2
+  resolution: "tinyexec@npm:0.3.2"
+  checksum: 10c0/3efbf791a911be0bf0821eab37a3445c2ba07acc1522b1fa84ae1e55f10425076f1290f680286345ed919549ad67527d07281f1c19d584df3b74326909eb1f90
+  languageName: node
+  linkType: hard
+
 "tinyglobby@npm:^0.2.12":
   version: 0.2.15
   resolution: "tinyglobby@npm:0.2.15"
@@ -5191,6 +6284,37 @@ __metadata:
     fdir: "npm:^6.5.0"
     picomatch: "npm:^4.0.3"
   checksum: 10c0/869c31490d0d88eedb8305d178d4c75e7463e820df5a9b9d388291daf93e8b1eb5de1dad1c1e139767e4269fe75f3b10d5009b2cc14db96ff98986920a186844
+  languageName: node
+  linkType: hard
+
+"tinyglobby@npm:^0.2.14, tinyglobby@npm:^0.2.15":
+  version: 0.2.17
+  resolution: "tinyglobby@npm:0.2.17"
+  dependencies:
+    fdir: "npm:^6.5.0"
+    picomatch: "npm:^4.0.4"
+  checksum: 10c0/7f7bb0f197c88bc4b20c231e0deca4240ca3bf313a88f5a7fee93a872b84966a4d50220947c0455ad07a60b3b360961c5b7fd979222aeb716a9f99b412002e4c
+  languageName: node
+  linkType: hard
+
+"tinypool@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "tinypool@npm:1.1.1"
+  checksum: 10c0/bf26727d01443061b04fa863f571016950888ea994ba0cd8cba3a1c51e2458d84574341ab8dbc3664f1c3ab20885c8cf9ff1cc4b18201f04c2cde7d317fff69b
+  languageName: node
+  linkType: hard
+
+"tinyrainbow@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "tinyrainbow@npm:2.0.0"
+  checksum: 10c0/c83c52bef4e0ae7fb8ec6a722f70b5b6fa8d8be1c85792e829f56c0e1be94ab70b293c032dc5048d4d37cfe678f1f5babb04bdc65fd123098800148ca989184f
+  languageName: node
+  linkType: hard
+
+"tinyspy@npm:^4.0.3":
+  version: 4.0.4
+  resolution: "tinyspy@npm:4.0.4"
+  checksum: 10c0/a8020fc17799251e06a8398dcc352601d2770aa91c556b9531ecd7a12581161fd1c14e81cbdaff0c1306c93bfdde8ff6d1c1a3f9bbe6d91604f0fd4e01e2f1eb
   languageName: node
   linkType: hard
 
@@ -5207,6 +6331,13 @@ __metadata:
   dependencies:
     is-number: "npm:^7.0.0"
   checksum: 10c0/487988b0a19c654ff3e1961b87f471702e708fa8a8dd02a298ef16da7206692e8552a0250e8b3e8759270f62e9d8314616f6da274734d3b558b1fc7b7724e892
+  languageName: node
+  linkType: hard
+
+"tr46@npm:~0.0.3":
+  version: 0.0.3
+  resolution: "tr46@npm:0.0.3"
+  checksum: 10c0/047cb209a6b60c742f05c9d3ace8fa510bff609995c129a37ace03476a9b12db4dbf975e74600830ef0796e18882b2381fb5fb1f6b4f96b832c374de3ab91a11
   languageName: node
   linkType: hard
 
@@ -5440,12 +6571,155 @@ __metadata:
   languageName: node
   linkType: hard
 
+"vite-node@npm:3.2.4":
+  version: 3.2.4
+  resolution: "vite-node@npm:3.2.4"
+  dependencies:
+    cac: "npm:^6.7.14"
+    debug: "npm:^4.4.1"
+    es-module-lexer: "npm:^1.7.0"
+    pathe: "npm:^2.0.3"
+    vite: "npm:^5.0.0 || ^6.0.0 || ^7.0.0-0"
+  bin:
+    vite-node: vite-node.mjs
+  checksum: 10c0/6ceca67c002f8ef6397d58b9539f80f2b5d79e103a18367288b3f00a8ab55affa3d711d86d9112fce5a7fa658a212a087a005a045eb8f4758947dd99af2a6c6b
+  languageName: node
+  linkType: hard
+
+"vite@npm:^5.0.0 || ^6.0.0 || ^7.0.0-0":
+  version: 7.3.5
+  resolution: "vite@npm:7.3.5"
+  dependencies:
+    esbuild: "npm:^0.27.0"
+    fdir: "npm:^6.5.0"
+    fsevents: "npm:~2.3.3"
+    picomatch: "npm:^4.0.3"
+    postcss: "npm:^8.5.6"
+    rollup: "npm:^4.43.0"
+    tinyglobby: "npm:^0.2.15"
+  peerDependencies:
+    "@types/node": ^20.19.0 || >=22.12.0
+    jiti: ">=1.21.0"
+    less: ^4.0.0
+    lightningcss: ^1.21.0
+    sass: ^1.70.0
+    sass-embedded: ^1.70.0
+    stylus: ">=0.54.8"
+    sugarss: ^5.0.0
+    terser: ^5.16.0
+    tsx: ^4.8.1
+    yaml: ^2.4.2
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+    jiti:
+      optional: true
+    less:
+      optional: true
+    lightningcss:
+      optional: true
+    sass:
+      optional: true
+    sass-embedded:
+      optional: true
+    stylus:
+      optional: true
+    sugarss:
+      optional: true
+    terser:
+      optional: true
+    tsx:
+      optional: true
+    yaml:
+      optional: true
+  bin:
+    vite: bin/vite.js
+  checksum: 10c0/4ad700649ed2ebd1e726d32f3f6e41eecbec4e29bcb5977805f3d43a5659280518aa431b0fc61adc1879df4fe1978d7cfc7dbbe54cdf014022385052967721e8
+  languageName: node
+  linkType: hard
+
+"vitest@npm:^3.2.0":
+  version: 3.2.6
+  resolution: "vitest@npm:3.2.6"
+  dependencies:
+    "@types/chai": "npm:^5.2.2"
+    "@vitest/expect": "npm:3.2.6"
+    "@vitest/mocker": "npm:3.2.6"
+    "@vitest/pretty-format": "npm:^3.2.6"
+    "@vitest/runner": "npm:3.2.6"
+    "@vitest/snapshot": "npm:3.2.6"
+    "@vitest/spy": "npm:3.2.6"
+    "@vitest/utils": "npm:3.2.6"
+    chai: "npm:^5.2.0"
+    debug: "npm:^4.4.1"
+    expect-type: "npm:^1.2.1"
+    magic-string: "npm:^0.30.17"
+    pathe: "npm:^2.0.3"
+    picomatch: "npm:^4.0.2"
+    std-env: "npm:^3.9.0"
+    tinybench: "npm:^2.9.0"
+    tinyexec: "npm:^0.3.2"
+    tinyglobby: "npm:^0.2.14"
+    tinypool: "npm:^1.1.1"
+    tinyrainbow: "npm:^2.0.0"
+    vite: "npm:^5.0.0 || ^6.0.0 || ^7.0.0-0"
+    vite-node: "npm:3.2.4"
+    why-is-node-running: "npm:^2.3.0"
+  peerDependencies:
+    "@edge-runtime/vm": "*"
+    "@types/debug": ^4.1.12
+    "@types/node": ^18.0.0 || ^20.0.0 || >=22.0.0
+    "@vitest/browser": 3.2.6
+    "@vitest/ui": 3.2.6
+    happy-dom: "*"
+    jsdom: "*"
+  peerDependenciesMeta:
+    "@edge-runtime/vm":
+      optional: true
+    "@types/debug":
+      optional: true
+    "@types/node":
+      optional: true
+    "@vitest/browser":
+      optional: true
+    "@vitest/ui":
+      optional: true
+    happy-dom:
+      optional: true
+    jsdom:
+      optional: true
+  bin:
+    vitest: vitest.mjs
+  checksum: 10c0/ea222dcd7310188479e37dbea4fbcbdcdb8db97f952b4813e7e7b370b329485c2de4622551e61076ffd75d4d811a6800a0da1e31520067614c51528f26704758
+  languageName: node
+  linkType: hard
+
 "walker@npm:^1.0.8":
   version: 1.0.8
   resolution: "walker@npm:1.0.8"
   dependencies:
     makeerror: "npm:1.0.12"
   checksum: 10c0/a17e037bccd3ca8a25a80cb850903facdfed0de4864bd8728f1782370715d679fa72e0a0f5da7c1c1379365159901e5935f35be531229da53bbfc0efdabdb48e
+  languageName: node
+  linkType: hard
+
+"webidl-conversions@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "webidl-conversions@npm:3.0.1"
+  checksum: 10c0/5612d5f3e54760a797052eb4927f0ddc01383550f542ccd33d5238cfd65aeed392a45ad38364970d0a0f4fea32e1f4d231b3d8dac4a3bdd385e5cf802ae097db
+  languageName: node
+  linkType: hard
+
+"whatwg-url@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "whatwg-url@npm:5.0.0"
+  dependencies:
+    tr46: "npm:~0.0.3"
+    webidl-conversions: "npm:^3.0.0"
+  checksum: 10c0/1588bed84d10b72d5eec1d0faa0722ba1962f1821e7539c535558fb5398d223b0c50d8acab950b8c488b4ba69043fd833cc2697056b167d8ad46fac3995a55d5
   languageName: node
   linkType: hard
 
@@ -5468,6 +6742,18 @@ __metadata:
   bin:
     node-which: bin/which.js
   checksum: 10c0/7e710e54ea36d2d6183bee2f9caa27a3b47b9baf8dee55a199b736fcf85eab3b9df7556fca3d02b50af7f3dfba5ea3a45644189836df06267df457e354da66d5
+  languageName: node
+  linkType: hard
+
+"why-is-node-running@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "why-is-node-running@npm:2.3.0"
+  dependencies:
+    siginfo: "npm:^2.0.0"
+    stackback: "npm:0.0.2"
+  bin:
+    why-is-node-running: cli.js
+  checksum: 10c0/1cde0b01b827d2cf4cb11db962f3958b9175d5d9e7ac7361d1a7b0e2dc6069a263e69118bd974c4f6d0a890ef4eedfe34cf3d5167ec14203dbc9a18620537054
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What does this PR do?

Adds the end-to-end instrumentation lifecycle test for the CloudFormation macro on AWS Lambda, plus its config, README, and CI workflow. `lambda.test.ts` builds the macro from source, registers it, and drives a workload Lambda through the full contract:

1. **APPLY** -- deploy the workload through the macro; assert config present (pinned Datadog Node + Extension layers, redirected handler, `DD_*` env, identifying tags).
2. **TRIGGER** -- invoke, then poll the Datadog API until spans **and** logs carrying the run identity (service/env/version/run id) appear.
3. **RE-APPLY** -- redeploy; assert no drift and no duplicated layers.
4. **REMOVE** -- `delete-stack`; assert the function and its DD config are gone.

### Infrastructure

Each run provisions two ephemeral, run-uniquely-named CloudFormation stacks. The macro under test is built from this repo's source (not a published release), so a failure points at the macro.

```mermaid
flowchart LR
  src["Macro source (this repo)"] -->|build_zip.sh| zip["Macro zip"]
  zip --> bucket["S3 source bucket"]

  subgraph macroStack["Macro stack"]
    bucket --> fn["Macro Lambda"]
    role["IAM role"] --> fn
    fn --> reg["CFN Macro registration"]
  end

  subgraph workloadStack["Workload stack"]
    wl["Workload Lambda (hello-world)"]
  end

  reg -.->|Transform on APPLY| wl
  ddAcct["Public DD layer acct 464622532012"] -->|Node + Extension layers| wl
```

The workload is first deployed uninstrumented (also the clean post-REMOVE end state), then redeployed with the macro's `Transform` applied -- that's APPLY, where the macro attaches the Datadog layers, `DD_*` env, handler redirect, and `dd_sls_macro` tag. Teardown always deletes both stacks and the source bucket; the cross-repo sweeper reclaims anything leaked by cancelled CI.

### CI

`.github/workflows/e2e.yml` runs the suite behind path filters. AWS creds come from OIDC, Datadog creds from dd-sts -- no long-lived secrets, and a missing credential fails loudly rather than skipping green.

### Testing Guidelines

Ran the full suite end-to-end locally against the serverless sandbox -- all four phases plus teardown pass.

### Additional Notes

- Layer/extension versions and the runtime are pinned (overridable via env) so failures blame the macro, not an upstream bump.
- Introduces vitest for e2e alongside the existing jest unit runner; a fast-follow migrates the unit specs to vitest and drops jest.

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
